### PR TITLE
Run migrations from makefile via env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,6 @@ local:
 
 aliases:
 	cd scripts/aliases && go run .
+
+migration:
+	cd scripts/migration && go run .

--- a/scripts/migration/main.go
+++ b/scripts/migration/main.go
@@ -1,31 +1,45 @@
 package main
 
 import (
+	"log"
+	"os"
+
 	"github.com/baking-bad/bcdhub/internal/contractparser/consts"
 	"github.com/baking-bad/bcdhub/internal/jsonload"
 	"github.com/baking-bad/bcdhub/scripts/migration/migrations"
 )
 
 func main() {
+	migrationMap := map[string]migrations.Migration{
+		"timestamp":       &migrations.SetTimestampMigration{},
+		"language":        &migrations.SetLanguageMigration{},
+		"contract_alias":  &migrations.SetContractAliasMigration{Network: consts.Mainnet},
+		"operation_alias": &migrations.SetOperationAliasMigration{Network: consts.Mainnet},
+	}
+
+	env := os.Getenv("MIGRATION")
+
+	if env == "" {
+		log.Fatal("MIGRATION env variable is not set.")
+	}
+
+	if _, ok := migrationMap[env]; !ok {
+		log.Fatal("Unknown migration key: ", env)
+	}
+
 	var cfg migrations.Config
 	if err := jsonload.StructFromFile("config.json", &cfg); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	cfg.Print()
 
 	ctx, err := migrations.NewContext(cfg)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	defer ctx.Close()
 
-	// migration := migrations.SetTimestampMigration{}
-	// migration := migrations.SetLanguageMigration{}
-	// migration := migrations.SetOperationAliasMigration{}
-	migration := migrations.SetContractAliasMigration{
-		Network: consts.Mainnet,
-	}
-	if err := migration.Do(ctx); err != nil {
-		panic(err)
+	if err := migrationMap[env].Do(ctx); err != nil {
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Run migration with command:
```MIGRATION=timestamp make migration```

available migration names:
- timestamp
- language
- contract_alias
- operation_alias