### PR TITLE
Add ProtoGenesis

### DIFF
--- a/cmd/indexer/indexer/boost.go
+++ b/cmd/indexer/indexer/boost.go
@@ -177,7 +177,11 @@ func (bi *BoostIndexer) Sync(wg *sync.WaitGroup) error {
 	}
 
 	everySecond := false
-	ticker := time.NewTicker(time.Duration(bi.UpdateTimer) * time.Second)
+	duration := time.Duration(bi.UpdateTimer) * time.Second
+	if duration.Microseconds() <= 0 {
+		duration = 1 * time.Second
+	}
+	ticker := time.NewTicker(duration)
 	for {
 		select {
 		case <-bi.stop:

--- a/internal/contractparser/meta/protocols.go
+++ b/internal/contractparser/meta/protocols.go
@@ -8,6 +8,7 @@ import (
 // Every time new protocol is proposed we determine if everything works fine or implement a custom handler otherwise
 // After that we append protocol to this list with a corresponding handler id (aka symlink)
 var symLinks = map[string]string{
+	"ProtoGenesisGenesisGenesisGenesisGenesisGenesk612im": "alpha",
 	"PrihK96nBAFSxVL1GLJTVhu9YnzkMFiBeuJRPA8NwuZVZCE1L6i": "alpha",
 	"PtBMwNZT94N7gXKw4i273CKcSaBrrBnqnt3RATExNKr9KNX2USV": "alpha",
 	"ProtoDemoNoopsDemoNoopsDemoNoopsDemoNoopsDemo6XBoYp": "alpha",


### PR DESCRIPTION
I tested this in a sandbox that starts with ProtoGenesis, injects Carthage and then bakes a few Blocks,

Initailly i got this error:

```
Unknown protocol: ProtoGenesisGenesisGenesisGenesisGenesisGenesk612im
```
just adding the Protocol to the symlins in `protocols.go` fixes this, however then i got the following error:

```
2020/05/18 21:14:15 [Info] [tplusnet] Creating indexer object...
2020/05/18 21:14:15 [Info] Elasticsearch Server: 7.5.1
2020/05/18 21:14:15 [Info] [tplusnet] Current indexer state: 5
2020/05/18 21:14:15 [Info] [tplusnet] Current network protocol: PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb
2020/05/18 21:14:15 [Info] [tplusnet] Getting network constants...
2020/05/18 21:14:15 [Info] [tplusnet] Data will be updated every 0 seconds
2020/05/18 21:14:15 [Info] [tplusnet] Current node state: 5
2020/05/18 21:14:15 [Info] [tplusnet] Current indexer state: 5
2020/05/18 21:14:15 [Error] Same level
panic: non-positive interval for NewTicker

goroutine 50 [running]:
time.NewTicker(0x0, 0xc00041a7c0)
        /home/johann/go/go1.14.1/src/time/tick.go:23 +0x147
github.com/baking-bad/bcdhub/cmd/indexer/indexer.(*BoostIndexer).Sync(0xc00040a160, 0xc000094020, 0x0, 0x0)
        /home/johann/Projects/bakingbad/bcdhub/cmd/indexer/indexer/boost.go:180 +0x117
created by main.main
        /home/johann/Projects/bakingbad/bcdhub/cmd/indexer/main.go:49 +0x2f1
exit status 2
```


second commit adds a check for this