### PR TITLE
Added: mark_all_read endpoint

### DIFF
--- a/cmd/api/handlers/requests.go
+++ b/cmd/api/handlers/requests.go
@@ -155,3 +155,7 @@ type runCodeRequest struct {
 	Source   string                 `json:"source,omitempty" binding:"omitempty,address"`
 	Sender   string                 `json:"sender,omitempty" binding:"omitempty,address"`
 }
+
+type markReadRequest struct {
+	Timestamp int64 `json:"timestamp"`
+}

--- a/cmd/api/handlers/user.go
+++ b/cmd/api/handlers/user.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -32,4 +33,30 @@ func (ctx *Context) GetUserProfile(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, profile)
+}
+
+// UserMarkAllRead -
+func (ctx *Context) UserMarkAllRead(c *gin.Context) {
+	userID := CurrentUserID(c)
+	if userID == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user"})
+		return
+	}
+
+	var req markReadRequest
+	if err := c.ShouldBindJSON(&req); handleError(c, err, http.StatusBadRequest) {
+		return
+	}
+
+	if req.Timestamp > time.Now().Unix() {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "timestamp can't be in the future"})
+		return
+	}
+
+	err := ctx.DB.UpdateUserMarkReadAt(userID, req.Timestamp)
+	if handleError(c, err, 0) {
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{})
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -180,6 +180,7 @@ func main() {
 			profile := authorized.Group("profile")
 			{
 				profile.GET("", ctx.GetUserProfile)
+				profile.GET("/mark_all_read", ctx.UserMarkAllRead)
 				subscriptions := profile.Group("subscriptions")
 				{
 					subscriptions.GET("", ctx.ListSubscriptions)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -11,6 +11,7 @@ type DB interface {
 	// User
 	GetOrCreateUser(*User) error
 	GetUser(uint) (*User, error)
+	UpdateUserMarkReadAt(uint, int64) error
 
 	// Subscription
 	GetSubscription(address, network string) (Subscription, error)

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -30,3 +30,7 @@ func (d *db) GetUser(userID uint) (*User, error) {
 
 	return &user, nil
 }
+
+func (d *db) UpdateUserMarkReadAt(userID uint, ts int64) error {
+	return d.ORM.Model(&User{}).Where("id = ?", userID).Update("mark_read_at", time.Unix(ts, 0)).Error
+}


### PR DESCRIPTION
**Request**: GET /v1/profile/mark_all_read
**Body**:
```json
{
	"timestamp": 1590586090
}
```

Эндпоинт принимает timestamp в формате Unix time (int64) и обновляет у текущего пользователя поле MarkReadAt 