### PR TITLE
GetBigMap: added contract alias. GetBigMapKeys: added skip_removed flag

### DIFF
--- a/cmd/api/handlers/bigmap.go
+++ b/cmd/api/handlers/bigmap.go
@@ -33,7 +33,7 @@ func (ctx *Context) GetBigMap(c *gin.Context) {
 		return
 	}
 
-	bm, err := ctx.ES.GetBigMapKeys(req.Ptr, req.Network, "", 10000, 0)
+	bm, err := ctx.ES.GetBigMapKeys(req.Ptr, req.Network, "", 10000, 0, false)
 	if handleError(c, err, 0) {
 		return
 	}
@@ -122,7 +122,7 @@ func (ctx *Context) GetBigMapKeys(c *gin.Context) {
 		return
 	}
 
-	bm, err := ctx.ES.GetBigMapKeys(req.Ptr, req.Network, pageReq.Search, pageReq.Size, pageReq.Offset)
+	bm, err := ctx.ES.GetBigMapKeys(req.Ptr, req.Network, pageReq.Search, pageReq.Size, pageReq.Offset, pageReq.SkipRemoved)
 	if handleError(c, err, 0) {
 		return
 	}
@@ -188,6 +188,11 @@ func (ctx *Context) prepareBigMap(data []elastic.BigMapDiff) (res GetBigMapRespo
 			res.ActiveKeys++
 		}
 	}
+
+	if alias, ok := ctx.Aliases[res.Address]; ok {
+		res.ContractAlias = alias
+	}
+
 	return
 }
 

--- a/cmd/api/handlers/requests.go
+++ b/cmd/api/handlers/requests.go
@@ -123,9 +123,10 @@ type getByNetwork struct {
 }
 
 type bigMapSearchRequest struct {
-	Offset int64  `form:"offset" binding:"min=0"`
-	Size   int64  `form:"size" binding:"min=0"`
-	Search string `form:"q"`
+	Offset      int64  `form:"offset" binding:"min=0"`
+	Size        int64  `form:"size" binding:"min=0"`
+	Search      string `form:"q"`
+	SkipRemoved bool   `form:"skip_removed"`
 }
 
 type getEntrypointDataRequest struct {

--- a/cmd/api/handlers/responses.go
+++ b/cmd/api/handlers/responses.go
@@ -288,10 +288,11 @@ type BigMapResponseItem struct {
 
 // GetBigMapResponse -
 type GetBigMapResponse struct {
-	Address    string `json:"address"`
-	Network    string `json:"network"`
-	Ptr        int64  `json:"ptr"`
-	ActiveKeys uint   `json:"active_keys"`
+	Address       string `json:"address"`
+	Network       string `json:"network"`
+	Ptr           int64  `json:"ptr"`
+	ActiveKeys    uint   `json:"active_keys"`
+	ContractAlias string `json:"contract_alias"`
 }
 
 // Migration -

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -56,6 +56,11 @@ func main() {
 		return
 	}
 	defer ctx.Close()
+	if err := ctx.LoadAliases(); err != nil {
+		logger.Error(err)
+		helpers.CatchErrorSentry(err)
+		return
+	}
 
 	if cfg.API.Seed.Enabled {
 		if err := seed.Run(ctx, cfg.Seed); err != nil {


### PR DESCRIPTION
- GetBigMap: **contract_alias** field
```json
{
	"address": "KT1VG2WtYdSWz5E7chTeAdDPZNy2MpP8pTfL",
	"network": "mainnet",
	"ptr": 4,
	"active_keys": 0,
	"contract_alias": "Atomex"
}
```
- GetBigMapKeys: **skip_removed** flag
```
/v1/bigmap/mainnet/4/keys?q=&offset=0&skip_removed=true
```