### PR TITLE
Fix Column "key_hash,ptr" not found issue on API when accessing OpertionTab from the bcdhub-gui frontend

### DIFF
--- a/internal/postgres/bigmapdiff/storage.go
+++ b/internal/postgres/bigmapdiff/storage.go
@@ -104,7 +104,7 @@ func (storage *Storage) Previous(filters []bigmapdiff.BigMapDiff) (response []bi
 		query.Where("id < ?", lastID)
 	}
 
-	query.Group("key_hash,ptr")
+	query.Group("key_hash")
 
 	err = storage.DB.Model().Table(models.DocBigMapDiff).
 		Where("id IN (?)", query).


### PR DESCRIPTION
When accessing to the operation tab from the frontend an error is displayed:
"Column key_hash,ptr not found"

This change fixes the issue