### PR TITLE
Added marking ghost contracts for failed operations

### DIFF
--- a/internal/bcd/literal.go
+++ b/internal/bcd/literal.go
@@ -62,6 +62,11 @@ func IsContract(str string) bool {
 	return contractRegex.MatchString(str)
 }
 
+// FindContract -
+func FindContract(str string) string {
+	return contractRegex.FindString(str)
+}
+
 // IsBakerHash -
 func IsBakerHash(str string) bool {
 	return bakerHashRegex.MatchString(str)

--- a/internal/parsers/operations/transaction.go
+++ b/internal/parsers/operations/transaction.go
@@ -117,7 +117,10 @@ func (p Transaction) parseContractParams(ctx context.Context, data noderpc.Opera
 		}
 		if tx.Errors[i].Is(consts.TezlinkError) &&
 			strings.Contains(tx.Errors[i].ErrorMessage, consts.TezlinkContractDoesNotExistMarker) {
-			return nil
+			if bcd.FindContract(tx.Errors[i].ErrorMessage) == tx.Destination.Address {
+				store.MarkAccountGhost(tx.Destination.Address)
+			}
+			return p.getEntrypoint(tx)
 		}
 	}
 


### PR DESCRIPTION
Mark ghost contracts on failed operations

Example: `KT1Dj2B1Wmz3vqaBzHhEZpjAhXu7CrQBEiy1`
https://previewnet.tezosx.tzkt.io/175384/operations