### PR TITLE
Return 400 instead of 500 for user input errors in entrypoint execution

### DIFF
--- a/cmd/api/handlers/error.go
+++ b/cmd/api/handlers/error.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/baking-bad/bcdhub/internal/bcd/ast"
+	"github.com/baking-bad/bcdhub/internal/bcd/consts"
 	"github.com/baking-bad/bcdhub/internal/models"
 	"github.com/baking-bad/bcdhub/internal/noderpc"
 	sentrygin "github.com/getsentry/sentry-go/gin"
@@ -46,7 +46,9 @@ func getErrorCode(err error, repo models.GeneralRepository) int {
 	if repo.IsRecordNotFound(err) {
 		return http.StatusNotFound
 	}
-	if errors.Is(err, ast.ErrValidation) {
+	if errors.Is(err, consts.ErrValidation) ||
+		errors.Is(err, consts.ErrJSONDataIsAbsent) ||
+		errors.Is(err, consts.ErrInvalidType) {
 		return http.StatusBadRequest
 	}
 	return http.StatusInternalServerError

--- a/cmd/api/handlers/error.go
+++ b/cmd/api/handlers/error.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"context"
 	"errors"
+	"net"
 	"net/http"
 
 	"github.com/baking-bad/bcdhub/internal/bcd/consts"
@@ -9,9 +11,16 @@ import (
 	"github.com/baking-bad/bcdhub/internal/noderpc"
 	sentrygin "github.com/getsentry/sentry-go/gin"
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgconn"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/rs/zerolog/log"
 )
+
+// pgQueryCanceled is raised by postgres when statement_timeout expires
+const pgQueryCanceled = "57014"
+
+// statusClientClosedRequest is the nginx convention for a client-aborted request
+const statusClientClosedRequest = 499
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
@@ -38,8 +47,20 @@ func handleError(c *gin.Context, repo models.GeneralRepository, err error, code 
 		log.Err(err).Msg("unexpected error")
 	}
 
-	c.AbortWithStatusJSON(code, getErrorMessage(err, repo))
+	c.AbortWithStatusJSON(code, getErrorMessage(err, code, repo))
 	return true
+}
+
+func isTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == pgQueryCanceled
 }
 
 func getErrorCode(err error, repo models.GeneralRepository) int {
@@ -51,12 +72,26 @@ func getErrorCode(err error, repo models.GeneralRepository) int {
 		errors.Is(err, consts.ErrInvalidType) {
 		return http.StatusBadRequest
 	}
+	if isTimeoutError(err) {
+		return http.StatusGatewayTimeout
+	}
+	if errors.Is(err, context.Canceled) {
+		return statusClientClosedRequest
+	}
 	return http.StatusInternalServerError
 }
 
-func getErrorMessage(err error, repo models.GeneralRepository) Error {
+func getErrorMessage(err error, code int, repo models.GeneralRepository) Error {
 	if repo.IsRecordNotFound(err) {
 		return Error{Message: "not found"}
+	}
+	switch code {
+	case http.StatusGatewayTimeout:
+		return Error{Message: "request timed out"}
+	case statusClientClosedRequest:
+		return Error{Message: "request canceled"}
+	case http.StatusInternalServerError:
+		return Error{Message: "internal server error"}
 	}
 	return Error{Message: err.Error()}
 }

--- a/internal/bcd/ast/ast_test.go
+++ b/internal/bcd/ast/ast_test.go
@@ -1474,7 +1474,7 @@ func TestTypedAst_FromJSONSchema(t *testing.T) {
 			err = a.FromJSONSchema(m)
 			if tt.wantErr {
 				require.Error(t, err)
-				require.ErrorIs(t, err, ErrValidation)
+				require.ErrorIs(t, err, consts.ErrValidation)
 				return
 			}
 			require.NoError(t, err)

--- a/internal/bcd/ast/jsonschema.go
+++ b/internal/bcd/ast/jsonschema.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/baking-bad/bcdhub/internal/bcd/consts"
 	"github.com/baking-bad/bcdhub/internal/bcd/types"
 	"github.com/pkg/errors"
 )
@@ -88,13 +89,13 @@ func setIntJSONSchema(d *Default, data map[string]interface{}) error {
 	case string:
 		value, err := types.NewBigIntFromString(v)
 		if err != nil {
-			return errors.Wrapf(ErrValidation, "invalid integer value: %s=%s", key, v)
+			return errors.Wrapf(consts.ErrValidation, "invalid integer value: %s=%s", key, v)
 		}
 		d.Value = value
 	case nil:
 		d.Value = &types.BigInt{}
 	default:
-		return errors.Wrapf(ErrValidation, "expected an integer value: %s=%v", key, value)
+		return errors.Wrapf(consts.ErrValidation, "expected an integer value: %s=%v", key, value)
 	}
 	d.ValueKind = valueKindInt
 	return nil

--- a/internal/bcd/ast/timestamp.go
+++ b/internal/bcd/ast/timestamp.go
@@ -83,7 +83,7 @@ func (t *Timestamp) FromJSONSchema(data map[string]interface{}) error {
 		case string:
 			ts, err := time.Parse(time.RFC3339, val)
 			if err != nil {
-				return errors.Wrapf(ErrValidation, "time should be in RFC3339  %s=%s", key, val)
+				return errors.Wrapf(consts.ErrValidation, "time should be in RFC3339  %s=%s", key, val)
 			}
 			t.Value = types.NewBigInt(ts.UTC().Unix())
 		case float64:
@@ -91,7 +91,7 @@ func (t *Timestamp) FromJSONSchema(data map[string]interface{}) error {
 		case nil:
 			t.Value = &types.BigInt{}
 		default:
-			return errors.Wrapf(ErrValidation, "expected a timestamp value: %s=%v", key, value)
+			return errors.Wrapf(consts.ErrValidation, "expected a timestamp value: %s=%v", key, value)
 		}
 		t.ValueKind = valueKindInt
 	}

--- a/internal/bcd/ast/validators.go
+++ b/internal/bcd/ast/validators.go
@@ -5,13 +5,9 @@ import (
 	"strings"
 
 	"github.com/baking-bad/bcdhub/internal/bcd"
+	"github.com/baking-bad/bcdhub/internal/bcd/consts"
 	"github.com/baking-bad/bcdhub/internal/bcd/encoding"
 	"github.com/pkg/errors"
-)
-
-// errors
-var (
-	ErrValidation = errors.New("validation error")
 )
 
 // ValidatorConstraint -
@@ -31,17 +27,17 @@ func AddressValidator(value string) error {
 	switch len(value) {
 	case 44, 42:
 		if !hexRegex.MatchString(value) {
-			return errors.Wrapf(ErrValidation, "address '%s' should be hexademical without prefixes", value)
+			return errors.Wrapf(consts.ErrValidation, "address '%s' should be hexademical without prefixes", value)
 		}
 	case 36:
 		if !bcd.IsAddressLazy(value) {
-			return errors.Wrapf(ErrValidation, "invalid address '%s'", value)
+			return errors.Wrapf(consts.ErrValidation, "invalid address '%s'", value)
 		}
 		if !bcd.IsAddress(value) {
-			return errors.Wrapf(ErrValidation, "invalid address '%s'", value)
+			return errors.Wrapf(consts.ErrValidation, "invalid address '%s'", value)
 		}
 	default:
-		return errors.Wrapf(ErrValidation, "invalid address '%s'", value)
+		return errors.Wrapf(consts.ErrValidation, "invalid address '%s'", value)
 	}
 
 	return nil
@@ -52,28 +48,28 @@ func ContractValidator(value string) error {
 	switch len(value) {
 	case 44, 42:
 		if !hexRegex.MatchString(value) {
-			return errors.Wrapf(ErrValidation, "contract '%s' should be hexademical without prefixes", value)
+			return errors.Wrapf(consts.ErrValidation, "contract '%s' should be hexademical without prefixes", value)
 		}
 	case 36:
 		if !bcd.IsContractLazy(value) {
-			return errors.Wrapf(ErrValidation, "invalid contract address '%s'", value)
+			return errors.Wrapf(consts.ErrValidation, "invalid contract address '%s'", value)
 		}
 		if !bcd.IsContract(value) {
-			return errors.Wrapf(ErrValidation, "invalid contract address '%s'", value)
+			return errors.Wrapf(consts.ErrValidation, "invalid contract address '%s'", value)
 		}
 	default:
 		if len(value) < 38 {
-			return errors.Wrap(ErrValidation, "invalid contract address length")
+			return errors.Wrap(consts.ErrValidation, "invalid contract address length")
 		}
 		if value[36] != '%' {
-			return errors.Wrap(ErrValidation, "invalid contract address format address%%entrypoint")
+			return errors.Wrap(consts.ErrValidation, "invalid contract address format address%%entrypoint")
 		}
 		address := value[:36]
 		if !bcd.IsContractLazy(address) {
-			return errors.Wrapf(ErrValidation, "invalid contract address '%s'", address)
+			return errors.Wrapf(consts.ErrValidation, "invalid contract address '%s'", address)
 		}
 		if !bcd.IsContract(address) {
-			return errors.Wrapf(ErrValidation, "invalid contract address '%s'", address)
+			return errors.Wrapf(consts.ErrValidation, "invalid contract address '%s'", address)
 		}
 	}
 
@@ -85,14 +81,14 @@ func BakerHashValidator(value string) error {
 	switch len(value) {
 	case 40:
 		if !hexRegex.MatchString(value) {
-			return errors.Wrapf(ErrValidation, "baker hash '%s' should be hexademical without prefixes", value)
+			return errors.Wrapf(consts.ErrValidation, "baker hash '%s' should be hexademical without prefixes", value)
 		}
 	case 36:
 		if !bcd.IsBakerHash(value) {
-			return errors.Wrapf(ErrValidation, "invalid baker hash '%s'", value)
+			return errors.Wrapf(consts.ErrValidation, "invalid baker hash '%s'", value)
 		}
 	default:
-		return errors.Wrap(ErrValidation, "invalid baker hash length")
+		return errors.Wrap(consts.ErrValidation, "invalid baker hash length")
 	}
 
 	return nil
@@ -103,7 +99,7 @@ func PublicKeyValidator(value string) error {
 	switch len(value) {
 	case 68, 66:
 		if !hexRegex.MatchString(value) {
-			return errors.Wrapf(ErrValidation, "public key '%s' should be hexademical without prefixes", value)
+			return errors.Wrapf(consts.ErrValidation, "public key '%s' should be hexademical without prefixes", value)
 		}
 	case 55, 54:
 		if strings.HasPrefix(value, encoding.PrefixED25519PublicKey) ||
@@ -111,9 +107,9 @@ func PublicKeyValidator(value string) error {
 			strings.HasPrefix(value, encoding.PrefixSecp256k1PublicKey) {
 			return nil
 		}
-		return errors.Wrapf(ErrValidation, "invalid public key '%s'", value)
+		return errors.Wrapf(consts.ErrValidation, "invalid public key '%s'", value)
 	default:
-		return errors.Wrap(ErrValidation, "invalid public key length")
+		return errors.Wrap(consts.ErrValidation, "invalid public key length")
 	}
 
 	return nil
@@ -122,10 +118,10 @@ func PublicKeyValidator(value string) error {
 // BytesValidator -
 func BytesValidator(value string) error {
 	if len(value)%2 > 0 {
-		return errors.Wrapf(ErrValidation, "invalid bytes in hex length '%s'", value)
+		return errors.Wrapf(consts.ErrValidation, "invalid bytes in hex length '%s'", value)
 	}
 	if value != "" && !hexRegex.MatchString(value) {
-		return errors.Wrapf(ErrValidation, "bytes '%s' should be hexademical without prefixes", value)
+		return errors.Wrapf(consts.ErrValidation, "bytes '%s' should be hexademical without prefixes", value)
 	}
 	return nil
 }
@@ -135,15 +131,15 @@ func ChainIDValidator(value string) error {
 	switch len(value) {
 	case 8:
 		if !hexRegex.MatchString(value) {
-			return errors.Wrapf(ErrValidation, "chain id '%s' should be hexademical without prefixes", value)
+			return errors.Wrapf(consts.ErrValidation, "chain id '%s' should be hexademical without prefixes", value)
 		}
 	case 15:
 		if strings.HasPrefix(value, encoding.PrefixChainID) {
 			return nil
 		}
-		return errors.Wrapf(ErrValidation, "invalid chain id '%s'", value)
+		return errors.Wrapf(consts.ErrValidation, "invalid chain id '%s'", value)
 	default:
-		return errors.Wrap(ErrValidation, "invalid chain id length")
+		return errors.Wrap(consts.ErrValidation, "invalid chain id length")
 	}
 
 	return nil
@@ -154,26 +150,26 @@ func SignatureValidator(value string) error {
 	switch len(value) {
 	case 128:
 		if !hexRegex.MatchString(value) {
-			return errors.Wrapf(ErrValidation, "signature '%s' should be hexademical without prefixes", value)
+			return errors.Wrapf(consts.ErrValidation, "signature '%s' should be hexademical without prefixes", value)
 		}
 	case 96:
 		if strings.HasPrefix(value, encoding.PrefixGenericSignature) {
 			return nil
 		}
-		return errors.Wrapf(ErrValidation, "invalid signature '%s'", value)
+		return errors.Wrapf(consts.ErrValidation, "invalid signature '%s'", value)
 	case 98:
 		if strings.HasPrefix(value, encoding.PrefixP256Signature) {
 			return nil
 		}
-		return errors.Wrapf(ErrValidation, "invalid signature '%s'", value)
+		return errors.Wrapf(consts.ErrValidation, "invalid signature '%s'", value)
 	case 99:
 		if strings.HasPrefix(value, encoding.PrefixED25519Signature) ||
 			strings.HasPrefix(value, encoding.PrefixSecp256k1Signature) {
 			return nil
 		}
-		return errors.Wrapf(ErrValidation, "invalid signature '%s'", value)
+		return errors.Wrapf(consts.ErrValidation, "invalid signature '%s'", value)
 	default:
-		return errors.Wrap(ErrValidation, "invalid signature length")
+		return errors.Wrap(consts.ErrValidation, "invalid signature length")
 	}
 
 	return nil


### PR DESCRIPTION
### Problem

Sentry was receiving noisy events like `Option.FromJSONSchema: JSON data is absent` from `POST /v1/contract/:network/:address/entrypoints/data` and `/entrypoints/trace`. These occur when a client submits an entrypoint execution form with empty/invalid data (e.g. calling `set_delegate` with `option(key_hash)` type and an empty `data: {}` payload, so the required `schemaKey` field is missing).

These are user input errors, but `getErrorCode` only recognized `ast.ErrValidation` as a Bad Request, so everything else from the `FromJSONSchema` parsing chain was classified as `500 Internal Server Error` and captured to Sentry.

### Changes

* `cmd/api/handlers/error.go`: `getErrorCode` now maps `consts.ErrValidation`, `consts.ErrJSONDataIsAbsent`, and `consts.ErrInvalidType` to `400 Bad Request`. Since these no longer resolve to 500, they are no longer reported to Sentry.
* Removed the duplicate `ast.ErrValidation` sentinel: the `ast` package had its own `ErrValidation` alongside `consts.ErrValidation`, which meant validation errors wrapped with the `consts` one (e.g. in `Map`/`List`/`Set`/`BigMap.FromJSONSchema`) were not matched by the handler. All usages in `ast` (validators, JSON schema, timestamp) now use `consts.ErrValidation`.