### PR TITLE
Optimize hot SQL queries

### DIFF
--- a/cmd/api/handlers/contract.go
+++ b/cmd/api/handlers/contract.go
@@ -99,7 +99,7 @@ func GetSameContracts() gin.HandlerFunc {
 			return
 		}
 
-		count, err := ctx.Domains.SameCount(c.Request.Context(), contract, ctx.Config.API.Networks...)
+		count, err := ctx.Cache.SameCount(c.Request.Context(), contract, ctx.Config.API.Networks...)
 		if handleError(c, ctx.Storage, err, 0) {
 			return
 		}
@@ -146,7 +146,7 @@ func contractWithStatsPostprocessing(c context.Context, ctx *config.Context, con
 	}
 	res := ContractWithStats{contract, 0}
 
-	stats, err := ctx.Domains.SameCount(c, contractModel, ctx.Config.API.Networks...)
+	stats, err := ctx.Cache.SameCount(c, contractModel, ctx.Config.API.Networks...)
 	if err != nil {
 		return res, err
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -2,14 +2,17 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/baking-bad/bcdhub/internal/bcd"
 	"github.com/baking-bad/bcdhub/internal/bcd/consts"
 	"github.com/baking-bad/bcdhub/internal/models/account"
 	"github.com/baking-bad/bcdhub/internal/models/contract"
+	"github.com/baking-bad/bcdhub/internal/models/domains"
 	"github.com/baking-bad/bcdhub/internal/models/protocol"
 	"github.com/baking-bad/bcdhub/internal/models/types"
 	"github.com/baking-bad/bcdhub/internal/noderpc"
@@ -24,6 +27,7 @@ type Cache struct {
 	accounts  account.Repository
 	contracts contract.Repository
 	protocols protocol.Repository
+	domains   domains.Repository
 	sanitizer *bluemonday.Policy
 
 	contractTags *ccache.Cache[types.Tags]
@@ -32,10 +36,11 @@ type Cache struct {
 	scriptBytes  *ccache.Cache[[]byte]
 	scripts      *ccache.Cache[contract.Script]
 	protocolById *ccache.Cache[protocol.Protocol]
+	sameCounts   *ccache.Cache[int]
 }
 
 // NewCache -
-func NewCache(rpc noderpc.INode, accounts account.Repository, contracts contract.Repository, protocols protocol.Repository) *Cache {
+func NewCache(rpc noderpc.INode, accounts account.Repository, contracts contract.Repository, protocols protocol.Repository, domains domains.Repository) *Cache {
 	sanitizer := bluemonday.UGCPolicy()
 	sanitizer.AllowAttrs("em")
 	return &Cache{
@@ -45,10 +50,12 @@ func NewCache(rpc noderpc.INode, accounts account.Repository, contracts contract
 		scriptBytes:  ccache.New(ccache.Configure[[]byte]().MaxSize(1000)),
 		scripts:      ccache.New(ccache.Configure[contract.Script]().MaxSize(1000)),
 		protocolById: ccache.New(ccache.Configure[protocol.Protocol]().MaxSize(1000)),
+		sameCounts:   ccache.New(ccache.Configure[int]().MaxSize(1000)),
 		rpc:          rpc,
 		accounts:     accounts,
 		contracts:    contracts,
 		protocols:    protocols,
+		domains:      domains,
 		sanitizer:    sanitizer,
 	}
 }
@@ -122,6 +129,24 @@ func (cache *Cache) Script(ctx context.Context, address, symLink string) (contra
 	if err != nil {
 		cache.scripts.Delete(key)
 		return contract.Script{}, err
+	}
+	return item.Value(), nil
+}
+
+// SameCount - the result depends only on script hash and networks set, so it is cached by that key
+func (cache *Cache) SameCount(ctx context.Context, c contract.Contract, availiableNetworks ...string) (int, error) {
+	script := c.CurrentScript()
+	if script == nil {
+		return 0, errors.New("invalid contract script")
+	}
+
+	key := fmt.Sprintf("same:%s:%s", script.Hash, strings.Join(availiableNetworks, ","))
+	item, err := cache.sameCounts.Fetch(key, 10*time.Minute, func() (int, error) {
+		return cache.domains.SameCount(ctx, c, availiableNetworks...)
+	})
+	if err != nil {
+		cache.sameCounts.Delete(key)
+		return 0, err
 	}
 	return item.Value(), nil
 }

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -64,7 +64,7 @@ func NewContext(network types.Network, opts ...ContextOption) *Context {
 	}
 
 	ctx.Cache = cache.NewCache(
-		ctx.RPC, ctx.Accounts, ctx.Contracts, ctx.Protocols,
+		ctx.RPC, ctx.Accounts, ctx.Contracts, ctx.Protocols, ctx.Domains,
 	)
 	return ctx
 }

--- a/internal/parsers/operations/operation_group_test.go
+++ b/internal/parsers/operations/operation_group_test.go
@@ -22,6 +22,7 @@ import (
 	mock_bmd "github.com/baking-bad/bcdhub/internal/models/mock/bigmapdiff"
 	mock_block "github.com/baking-bad/bcdhub/internal/models/mock/block"
 	mock_contract "github.com/baking-bad/bcdhub/internal/models/mock/contract"
+	mock_domains "github.com/baking-bad/bcdhub/internal/models/mock/domains"
 	mock_operations "github.com/baking-bad/bcdhub/internal/models/mock/operation"
 	mock_proto "github.com/baking-bad/bcdhub/internal/models/mock/protocol"
 	"github.com/baking-bad/bcdhub/internal/models/operation"
@@ -74,6 +75,10 @@ func TestGroup_Parse(t *testing.T) {
 	ctrlOperationsRepo := gomock.NewController(t)
 	defer ctrlOperationsRepo.Finish()
 	operaitonsRepo := mock_operations.NewMockRepository(ctrlOperationsRepo)
+
+	ctrlDomainsRepo := gomock.NewController(t)
+	defer ctrlDomainsRepo.Finish()
+	domainsRepo := mock_domains.NewMockRepository(ctrlDomainsRepo)
 
 	ctrlRPC := gomock.NewController(t)
 	defer ctrlRPC.Finish()
@@ -405,7 +410,7 @@ func TestGroup_Parse(t *testing.T) {
 				Operations:  operaitonsRepo,
 				Scripts:     scriptRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{
@@ -441,7 +446,7 @@ func TestGroup_Parse(t *testing.T) {
 				Operations:  operaitonsRepo,
 				Scripts:     scriptRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{
@@ -652,7 +657,7 @@ func TestGroup_Parse(t *testing.T) {
 				Operations:  operaitonsRepo,
 				Scripts:     scriptRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{
@@ -858,7 +863,7 @@ func TestGroup_Parse(t *testing.T) {
 				Operations:  operaitonsRepo,
 				Scripts:     scriptRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{
@@ -977,7 +982,7 @@ func TestGroup_Parse(t *testing.T) {
 				Operations:  operaitonsRepo,
 				Scripts:     scriptRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{
@@ -1088,7 +1093,7 @@ func TestGroup_Parse(t *testing.T) {
 				Operations:  operaitonsRepo,
 				Scripts:     scriptRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{
@@ -1298,7 +1303,7 @@ func TestGroup_Parse(t *testing.T) {
 				Operations:  operaitonsRepo,
 				Scripts:     scriptRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{
@@ -1403,7 +1408,7 @@ func TestGroup_Parse(t *testing.T) {
 				Operations:  operaitonsRepo,
 				Scripts:     scriptRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{
@@ -1552,7 +1557,7 @@ func TestGroup_Parse(t *testing.T) {
 				Operations:  operaitonsRepo,
 				Scripts:     scriptRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{
@@ -1627,7 +1632,7 @@ func TestGroup_Parse(t *testing.T) {
 				Operations:  operaitonsRepo,
 				Scripts:     scriptRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			storage: map[string]int64{
@@ -2279,7 +2284,7 @@ func TestGroup_Parse(t *testing.T) {
 				Scripts:         scriptRepo,
 				GlobalConstants: globalConstantRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{
@@ -2398,7 +2403,7 @@ func TestGroup_Parse(t *testing.T) {
 				Scripts:         scriptRepo,
 				GlobalConstants: globalConstantRepo,
 				Cache: cache.NewCache(
-					rpc, accountsRepo, contractRepo, protoRepo,
+					rpc, accountsRepo, contractRepo, protoRepo, domainsRepo,
 				),
 			},
 			paramsOpts: []ParseParamsOption{

--- a/internal/postgres/core/index.go
+++ b/internal/postgres/core/index.go
@@ -44,12 +44,11 @@ func createBaseIndices(ctx context.Context, db bun.IDB) error {
 		if _, err := db.NewCreateIndex().
 			Model((*bigmapdiff.BigMapDiff)(nil)).
 			IfNotExists().
-			Index("big_map_diff_key_hash_idx").
-			ColumnExpr("key_hash, ptr").
+			Index("big_map_diff_key_hash_id_idx").
+			ColumnExpr("key_hash, ptr, id").
 			Exec(ctx); err != nil {
 			return err
 		}
-
 		// Big map state
 		if _, err := db.NewCreateIndex().
 			Model((*bigmapdiff.BigMapState)(nil)).
@@ -135,6 +134,14 @@ func createBaseIndices(ctx context.Context, db bun.IDB) error {
 			IfNotExists().
 			Index("operations_status_idx").
 			Column("status").
+			Exec(ctx); err != nil {
+			return err
+		}
+		if _, err := db.NewCreateIndex().
+			Model((*operation.Operation)(nil)).
+			IfNotExists().
+			Index("operations_source_id_kind_idx").
+			ColumnExpr("source_id, kind, id").
 			Exec(ctx); err != nil {
 			return err
 		}

--- a/internal/postgres/domains/storage.go
+++ b/internal/postgres/domains/storage.go
@@ -22,6 +22,13 @@ func NewStorage(pg *core.Postgres) *Storage {
 	return &Storage{pg}
 }
 
+func (storage *Storage) scriptIDs(schema bun.Safe, hash string) *bun.SelectQuery {
+	return storage.DB.NewSelect().
+		TableExpr("?.scripts", schema).
+		Column("id").
+		Where("hash = ?", hash)
+}
+
 // Same -
 func (storage *Storage) Same(ctx context.Context, network string, c contract.Contract, limit, offset int, availiableNetworks ...string) ([]domains.Same, error) {
 	if limit < 1 || limit > 10 {
@@ -51,14 +58,11 @@ func (storage *Storage) Same(ctx context.Context, network string, c contract.Con
 			ColumnExpr("contracts.*").
 			ColumnExpr("accounts.address as account__address, accounts.last_action as account__last_action").
 			Join("LEFT JOIN ?.accounts on contracts.account_id = accounts.id", schema).
-			Join("LEFT JOIN ?.scripts as alpha on alpha.id = contracts.alpha_id", schema).
-			Join("LEFT JOIN ?.scripts as babylon on babylon.id = contracts.babylon_id", schema).
-			Join("LEFT JOIN ?.scripts as jakarta on jakarta.id = contracts.jakarta_id", schema).
 			WhereGroup(" AND ", func(sq *bun.SelectQuery) *bun.SelectQuery {
 				return sq.
-					Where("alpha.hash = ?", script.Hash).
-					WhereOr("babylon.hash = ?", script.Hash).
-					WhereOr("jakarta.hash = ?", script.Hash)
+					Where("alpha_id IN (?)", storage.scriptIDs(schema, script.Hash)).
+					WhereOr("babylon_id IN (?)", storage.scriptIDs(schema, script.Hash)).
+					WhereOr("jakarta_id IN (?)", storage.scriptIDs(schema, script.Hash))
 			})
 
 		if value == network {
@@ -99,12 +103,9 @@ func (storage *Storage) SameCount(ctx context.Context, c contract.Contract, avai
 		query := storage.DB.NewSelect().
 			TableExpr("?.contracts", schema).
 			ColumnExpr("count(*) as c").
-			Join("LEFT JOIN ?.scripts as alpha on alpha.id = contracts.alpha_id", schema).
-			Join("LEFT JOIN ?.scripts as babylon on babylon.id = contracts.babylon_id", schema).
-			Join("LEFT JOIN ?.scripts as jakarta on jakarta.id = contracts.jakarta_id", schema).
-			Where("alpha.hash = ?", script.Hash).
-			WhereOr("babylon.hash = ?", script.Hash).
-			WhereOr("jakarta.hash = ?", script.Hash)
+			Where("alpha_id IN (?)", storage.scriptIDs(schema, script.Hash)).
+			WhereOr("babylon_id IN (?)", storage.scriptIDs(schema, script.Hash)).
+			WhereOr("jakarta_id IN (?)", storage.scriptIDs(schema, script.Hash))
 
 		if i == 0 {
 			union = query

--- a/internal/postgres/domains/storage.go
+++ b/internal/postgres/domains/storage.go
@@ -69,6 +69,9 @@ func (storage *Storage) Same(ctx context.Context, network string, c contract.Con
 			query.Where("contracts.id != ?", c.ID)
 		}
 
+		// the outer query takes at most limit+offset rows, no need to pull more from any network
+		query.Limit(limit + offset)
+
 		if i == 0 {
 			union = query
 		} else {
@@ -77,11 +80,13 @@ func (storage *Storage) Same(ctx context.Context, network string, c contract.Con
 	}
 
 	var same []domains.Same
-	err := storage.DB.NewSelect().
-		TableExpr("(?) as same", union).
-		Limit(limit).
-		Offset(offset).
-		Scan(ctx, &same)
+	err := storage.runWithoutParallelism(ctx, func(tx bun.Tx) error {
+		return tx.NewSelect().
+			TableExpr("(?) as same", union).
+			Limit(limit).
+			Offset(offset).
+			Scan(ctx, &same)
+	})
 	return same, err
 }
 
@@ -115,7 +120,10 @@ func (storage *Storage) SameCount(ctx context.Context, c contract.Contract, avai
 	}
 
 	var count int
-	if err := storage.DB.NewSelect().ColumnExpr("sum(c)").TableExpr("(?) as same", union).Scan(ctx, &count); err != nil {
+	err := storage.runWithoutParallelism(ctx, func(tx bun.Tx) error {
+		return tx.NewSelect().ColumnExpr("sum(c)").TableExpr("(?) as same", union).Scan(ctx, &count)
+	})
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil
 		}
@@ -123,4 +131,15 @@ func (storage *Storage) SameCount(ctx context.Context, c contract.Contract, avai
 	}
 
 	return count - 1, nil
+}
+
+// runWithoutParallelism - parallel plans allocate DSM segments in /dev/shm, which is limited
+// inside a container; bitmap scans over popular script hashes are cheap enough single-threaded
+func (storage *Storage) runWithoutParallelism(ctx context.Context, fn func(tx bun.Tx) error) error {
+	return storage.DB.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		if _, err := tx.ExecContext(ctx, "SET LOCAL max_parallel_workers_per_gather = 0"); err != nil {
+			return err
+		}
+		return fn(tx)
+	})
 }


### PR DESCRIPTION
### Changes

- **`Same` / `SameCount` rewritten**: script id is resolved via the unique `script_hash_idx` subquery, contracts are filtered by FK indexes (BitmapOr) — instead of triple `LEFT JOIN scripts` with `OR` across joins that bypassed all indexes.
- **`SameCount` is now cached** (10 min TTL, keyed by script hash + networks) — it was executed on every contract page view.
- **New index `operations (source_id, kind, id)`** — fixes 24s-mean `ListEvents` chunk scans.
- **New index `big_map_diffs (key_hash, ptr, id)`** — keyset pagination without a sort step; supersedes `big_map_diff_key_hash_idx` (drop manually).