### PR TITLE
Fix indexer races, shutdown hangs and rollback correctness issues

### DIFF
--- a/cmd/indexer/indexer/create.go
+++ b/cmd/indexer/indexer/create.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	"github.com/baking-bad/bcdhub/internal/bcd/tezerrors"
@@ -19,12 +20,19 @@ func CreateIndexers(ctx context.Context, cfg config.Config, g workerpool.Group) 
 	var (
 		mx       sync.Mutex
 		indexers = make([]Indexer, 0)
+		wg       = new(sync.WaitGroup)
 	)
 
 	for network, indexerCfg := range cfg.Indexer.Networks {
+		networkCfg := cfg
+		networkCfg.RPC = maps.Clone(cfg.RPC)
+
+		wg.Add(1)
 		go func(network string, indexerCfg config.IndexerConfig) {
+			defer wg.Done()
+
 			if indexerCfg.Periodic != nil {
-				periodicIndexer, err := NewPeriodicIndexer(ctx, network, cfg, indexerCfg, g)
+				periodicIndexer, err := NewPeriodicIndexer(ctx, network, networkCfg, indexerCfg, g)
 				if err != nil {
 					log.Err(err).Msg("NewPeriodicIndexer")
 					return
@@ -35,7 +43,7 @@ func CreateIndexers(ctx context.Context, cfg config.Config, g workerpool.Group) 
 
 				g.GoCtx(ctx, periodicIndexer.Start)
 			} else {
-				bi, err := NewBlockchainIndexer(ctx, cfg, network, indexerCfg)
+				bi, err := NewBlockchainIndexer(ctx, networkCfg, network, indexerCfg)
 				if err != nil {
 					log.Err(err).Msg("NewBlockchainIndexer")
 					return
@@ -49,5 +57,6 @@ func CreateIndexers(ctx context.Context, cfg config.Config, g workerpool.Group) 
 		}(network, indexerCfg)
 	}
 
+	wg.Wait()
 	return indexers, nil
 }

--- a/cmd/indexer/indexer/indexer.go
+++ b/cmd/indexer/indexer/indexer.go
@@ -91,9 +91,12 @@ func (bi *BlockchainIndexer) Close() error {
 
 	close(bi.refreshTimer)
 	if err := bi.receiver.Close(); err != nil {
-		return nil
+		log.Err(err).Msg("closing receiver")
 	}
-	return bi.Context.Close()
+	if err := bi.Context.Close(); err != nil {
+		log.Err(err).Msg("closing context")
+	}
+	return nil
 }
 
 func (bi *BlockchainIndexer) init(ctx context.Context, db *core.Postgres) error {

--- a/cmd/indexer/indexer/periodic.go
+++ b/cmd/indexer/indexer/periodic.go
@@ -51,12 +51,17 @@ func NewPeriodicIndexer(
 	p.worker.Start(ctx)
 
 	for worker.URL() == "" {
-		time.Sleep(time.Second)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			time.Sleep(time.Second)
+		}
 	}
 
 	setUrlToConfig(&p.cfg, worker.URL(), network)
 
-	bi, err := NewBlockchainIndexer(ctx, cfg, network, indexerCfg)
+	bi, err := NewBlockchainIndexer(ctx, p.cfg, network, indexerCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -92,6 +97,12 @@ func (p *PeriodicIndexer) Rollback(ctx context.Context) error {
 
 func (p *PeriodicIndexer) handleUrlChanged(ctx context.Context, network, url string) error {
 	log.Warn().Str("network", network).Str("url", url).Msg("cancelling indexer due to URL changing...")
+	if p.indexerCancel == nil {
+		return errors.New("indexer cancel func is nil")
+	}
+	if p.indexer == nil {
+		return errors.New("indexer is nil")
+	}
 	p.indexerCancel()
 
 	if err := p.indexer.Close(); err != nil {

--- a/cmd/indexer/indexer/receiver.go
+++ b/cmd/indexer/indexer/receiver.go
@@ -99,7 +99,11 @@ func (r *Receiver) job(ctx context.Context, level int64) {
 		func() (string, error) {
 			block, err := r.get(ctx, level)
 			if err == nil {
-				r.blocks <- &block
+				select {
+				case <-ctx.Done():
+					return "ok", nil
+				case r.blocks <- &block:
+				}
 				r.inProcess.Delete(level)
 				return "ok", nil
 			}

--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -45,6 +45,9 @@ func main() {
 	g := workerpool.NewGroup()
 	ctx, cancel := context.WithCancel(context.Background())
 
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+
 	indexers, err := indexer.CreateIndexers(ctx, cfg, g)
 	if err != nil {
 		cancel()
@@ -52,9 +55,6 @@ func main() {
 		helpers.CatchErrorSentry(err)
 		return
 	}
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 
 	<-sigChan
 	cancel()

--- a/internal/parsers/storage/babylon.go
+++ b/internal/parsers/storage/babylon.go
@@ -145,7 +145,7 @@ func (b *Babylon) handleBigMapDiff(ctx context.Context, result *noderpc.Operatio
 	}
 
 	if err := b.initPointersTypes(ctx, result, op, storageData); err != nil {
-		return nil
+		return errors.Wrap(err, "Babylon.initPointersTypes")
 	}
 
 	handlers := map[string]func(context.Context, noderpc.BigMapDiff, string, *operation.Operation, parsers.Store) error{

--- a/internal/parsers/storage/lazy_babylon.go
+++ b/internal/parsers/storage/lazy_babylon.go
@@ -157,7 +157,7 @@ func (b *LazyBabylon) handleBigMapDiff(ctx context.Context, result *noderpc.Oper
 	}
 
 	if err := b.initPointersTypes(ctx, result, op, storageData); err != nil {
-		return nil
+		return errors.Wrap(err, "LazyBabylon.initPointersTypes")
 	}
 
 	handlers := map[string]func(context.Context, *noderpc.LazyBigMapDiff, int64, string, *operation.Operation, parsers.Store) error{

--- a/internal/postgres/domains/storage.go
+++ b/internal/postgres/domains/storage.go
@@ -129,7 +129,9 @@ func (storage *Storage) SameCount(ctx context.Context, c contract.Contract, avai
 		}
 		return 0, err
 	}
-
+	if count == 0 {
+		return 0, nil
+	}
 	return count - 1, nil
 }
 

--- a/internal/postgres/operation/storage.go
+++ b/internal/postgres/operation/storage.go
@@ -106,23 +106,22 @@ func (storage *Storage) GetByID(ctx context.Context, id int64) (result operation
 
 // OPG -
 func (storage *Storage) OPG(ctx context.Context, address string, size, lastID int64) ([]operation.OPG, error) {
-	var accountID int64
+	var acc account.Account
 	if err := storage.DB.NewSelect().
-		Model((*account.Account)(nil)).
-		Column("id").
+		Model(&acc).
+		Column("id", "last_action").
 		Where("address = ?", address).
-		Scan(ctx, &accountID); err != nil {
+		Scan(ctx); err != nil {
 		return nil, err
 	}
 
 	var (
 		end        bool
 		result     = make([]operation.OPG, 0)
-		lastAction = time.Now().UTC()
+		lastAction = acc.LastAction
 		limit      = storage.GetPageSize(size)
 	)
 
-	lastActionSet := false
 	if lastID > 0 {
 		op, err := storage.GetByID(ctx, lastID)
 		if err != nil {
@@ -131,16 +130,6 @@ func (storage *Storage) OPG(ctx context.Context, address string, size, lastID in
 			}
 		} else {
 			lastAction = op.Timestamp
-			lastActionSet = true
-		}
-	}
-	if !lastActionSet {
-		if err := storage.DB.NewSelect().
-			Model((*account.Account)(nil)).
-			Column("last_action").
-			Where("id = ?", accountID).
-			Scan(ctx, &lastAction); err != nil {
-			return nil, err
 		}
 	}
 
@@ -154,7 +143,7 @@ func (storage *Storage) OPG(ctx context.Context, address string, size, lastID in
 			Column("id", "hash", "counter", "status", "kind", "level", "timestamp", "content_index", "entrypoint").
 			WhereGroup(" AND ",
 				func(q *bun.SelectQuery) *bun.SelectQuery {
-					return q.Where("destination_id = ?", accountID).WhereOr("source_id = ?", accountID)
+					return q.Where("destination_id = ?", acc.ID).WhereOr("source_id = ?", acc.ID)
 				},
 			).
 			Where("timestamp < ?", endTime).
@@ -208,7 +197,7 @@ func (storage *Storage) OPG(ctx context.Context, address string, size, lastID in
 			limit ?2
 		) as ta
 		order by last_id desc
-	`, subQuery, accountID, limit, startTime, endTime).Scan(ctx, &opg); err != nil {
+	`, subQuery, acc.ID, limit, startTime, endTime).Scan(ctx, &opg); err != nil {
 			return nil, err
 		}
 
@@ -218,15 +207,9 @@ func (storage *Storage) OPG(ctx context.Context, address string, size, lastID in
 		}
 
 		result = append(result, opg...)
+		lastAction = lastAction.AddDate(0, -3, 0)
 
-		if len(result) < limit {
-			lastAction = lastAction.AddDate(0, -3, 0)
-			if lastAction.Before(consts.BeginningOfTime) {
-				break
-			}
-		}
-
-		end = len(result) == limit
+		end = len(result) == limit || lastAction.Before(consts.BeginningOfTime)
 	}
 
 	return result, nil

--- a/internal/postgres/rollback.go
+++ b/internal/postgres/rollback.go
@@ -169,9 +169,19 @@ func (r Rollback) Protocols(ctx context.Context, level int64) error {
 		return nil
 	}
 
+	var lastProtocol int64
+	if err := r.tx.NewSelect().
+		Model((*protocol.Protocol)(nil)).
+		Column("id").
+		Order("start_level DESC").
+		Limit(1).
+		Scan(ctx, &lastProtocol); err != nil {
+		return err
+	}
+
 	_, err = r.tx.NewUpdate().
 		Model((*protocol.Protocol)(nil)).
-		Where("start_level < ?", level).
+		Where("id = (?)", lastProtocol).
 		Set("end_level = 0").
 		Exec(ctx)
 	return err

--- a/internal/rollback/rollback.go
+++ b/internal/rollback/rollback.go
@@ -58,7 +58,11 @@ func (rm Manager) Rollback(ctx context.Context, network types.Network, fromState
 
 		if err := rm.rollbackBlock(ctx, level); err != nil {
 			log.Err(err).Str("network", network.String()).Msg("rollback error")
-			return rm.rollback.Rollback()
+			if rollbackErr := rm.rollback.Rollback(); rollbackErr != nil {
+				log.Err(rollbackErr).Str("network", network.String()).Msg("failed to rollback")
+				return errors.Wrapf(err, "tx rollback also failed: %v", rollbackErr)
+			}
+			return err
 		}
 
 		log.Info().Str("network", network.String()).Msgf("rolled back to %d", level)
@@ -104,7 +108,7 @@ func (rm Manager) rollbackBlock(ctx context.Context, level int64) error {
 func (rm Manager) rollbackMigrations(ctx context.Context, level int64, rCtx *rollbackContext) error {
 	migrations, err := rm.rollback.GetMigrations(ctx, level)
 	if err != nil {
-		return nil
+		return errors.Wrap(err, "get migrations")
 	}
 	if len(migrations) == 0 {
 		return nil
@@ -115,7 +119,7 @@ func (rm Manager) rollbackMigrations(ctx context.Context, level int64, rCtx *rol
 	}
 
 	if _, err := rm.rollback.DeleteAll(ctx, (*migration.Migration)(nil), level); err != nil {
-		return err
+		return errors.Wrap(err, "delete migrations")
 	}
 	log.Info().Msg("rollback migrations")
 	return nil


### PR DESCRIPTION
## What's changed

A batch of bug fixes found during a code audit: data races and shutdown hangs in the indexer, swallowed errors, and data-correctness issues in the rollback and query layers.

### Indexer

* **`CreateIndexers` no longer returns before all indexers are created.** Previously the function spawned per-network goroutines and returned the `indexers` slice immediately, so on a fast shutdown some indexers could be missing from the slice and never closed. Now it waits for all creation goroutines (`sync.WaitGroup`).
* **Fixed a concurrent map read/write crash on shared config.** `config.Config` was copied shallowly, so all networks shared one `cfg.RPC` map; the periodic indexer mutated it (`setUrlToConfig`) while other networks' goroutines were reading it during startup. Each network now gets its own clone of the RPC map. `NewPeriodicIndexer` also passes the mutated copy (`p.cfg`) to `NewBlockchainIndexer` explicitly instead of relying on the shared-map side effect.
* **Fixed a shutdown hang in `Receiver`.** The block send (`r.blocks <- &block`) is now wrapped in a `select` with `ctx.Done()`, so worker goroutines no longer block forever when the consumer has already exited on context cancellation.
* **`BlockchainIndexer.Close` no longer swallows the receiver close error** (previously it returned `nil` on error).
* **Periodic indexer URL wait loop respects context cancellation.**

### Rollback

* **Protocol rollback no longer corrupts protocol history.** `Rollback.Protocols` used to reset `end_level = 0` for *all* protocols below the rollback level; now only the latest remaining protocol (which becomes current again) is reopened.
* **`rollbackMigrations` no longer swallows the `GetMigrations` error.** Previously a failed fetch silently skipped the migration rollback, leaving stale migration rows and wrong account counters.
* **Original error is preserved when the transaction rollback itself fails** (previously the tx rollback error replaced it).

### Parsers

* **Big map diff handling no longer silently drops data.** `Babylon`/`LazyBabylon` `handleBigMapDiff` swallowed `initPointersTypes` errors and skipped all big map diffs of the operation without a trace; the error is now propagated.

### Storage / API queries

* **`SameCount` returns 0 instead of -1** when there are no matching contracts.
* **`OPG` query simplified:** account `id` and `last_action` are fetched in a single query, removing the second lookup and the `lastActionSet` flag; pagination loop restructured (behavior unchanged).