### PR TITLE
Skip Sentry reporting for context cancellation errors on indexer shutdown

### DIFF
--- a/cmd/indexer/indexer/indexer.go
+++ b/cmd/indexer/indexer/indexer.go
@@ -244,6 +244,9 @@ func (bi *BlockchainIndexer) Start(ctx context.Context) {
 // reportProcessError logs a process loop error and sends it to Sentry,
 // except transient network failures: the next tick retries them anyway.
 func (bi *BlockchainIndexer) reportProcessError(hub *sentry.Hub, err error) {
+	if errors.Is(err, context.Canceled) {
+		return
+	}
 	if helpers.IsTransientError(err) {
 		log.Warn().Err(err).Str("network", bi.Network.String()).Msg("processing: transient network error")
 		return

--- a/cmd/indexer/indexer/indexer_test.go
+++ b/cmd/indexer/indexer/indexer_test.go
@@ -1,0 +1,67 @@
+package indexer
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/baking-bad/bcdhub/internal/models/types"
+	"github.com/getsentry/sentry-go"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type capturingTransport struct {
+	events []*sentry.Event
+}
+
+func (t *capturingTransport) Configure(options sentry.ClientOptions) {}
+func (t *capturingTransport) SendEvent(event *sentry.Event) {
+	t.events = append(t.events, event)
+}
+func (t *capturingTransport) Flush(timeout time.Duration) bool { return true }
+
+func TestReportProcessError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		sent int
+	}{
+		{
+			name: "context canceled on shutdown",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://rpc.tzkt.io/mainnet/chains/main/blocks/head/header",
+				Err: context.Canceled,
+			},
+			sent: 0,
+		},
+		{
+			name: "transient network error",
+			err:  errors.Wrap(context.DeadlineExceeded, "request head"),
+			sent: 0,
+		},
+		{
+			name: "regular error",
+			err:  errors.New("unexpected response"),
+			sent: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := new(capturingTransport)
+			client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport})
+			require.NoError(t, err)
+			hub := sentry.NewHub(client, sentry.NewScope())
+
+			bi := &BlockchainIndexer{
+				Network: types.Mainnet,
+			}
+			bi.reportProcessError(hub, tt.err)
+
+			require.Len(t, transport.events, tt.sent)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When the indexer is stopped (deploy, container restart), the parent context gets canceled while the processing loop may be in the middle of an RPC request to the node. The request fails with `*url.Error` wrapping `context.Canceled`, and `reportProcessError` sends it to Sentry.

This is not an actual failure — on the next loop iteration `select` hits `ctx.Done()` and the indexer exits normally. These events are pure noise in Sentry, fired on every graceful shutdown.

## Solution

Add an early return in `reportProcessError` when the error is (or wraps) `context.Canceled`. The check is intentionally kept separate from `helpers.IsTransientError`: context cancellation is not a transient network failure that will succeed on retry — there will be no retry, the loop is shutting down.

## Changes

- `cmd/indexer/indexer/indexer.go` — skip logging and Sentry reporting in `reportProcessError` when `errors.Is(err, context.Canceled)`.
- `cmd/indexer/indexer/indexer_test.go` — new `TestReportProcessError` using a capturing Sentry transport, covering three cases: wrapped `context.Canceled` (not reported), transient network error (not reported), regular error (reported).