### PR TITLE
Fix: seed operations.Last search from account last_action

### DIFF
--- a/cmd/api/handlers/entrypoints.go
+++ b/cmd/api/handlers/entrypoints.go
@@ -211,6 +211,7 @@ func GetEntrypointSchema() gin.HandlerFunc {
 						"kind":           modelTypes.OperationKindTransaction,
 						"entrypoint":     esReq.EntrypointName,
 						"status":         modelTypes.OperationStatusApplied,
+						"last_action":    account.LastAction,
 					}, 0)
 				if handleError(c, ctx.Storage, err, 0) {
 					return

--- a/cmd/api/handlers/storage.go
+++ b/cmd/api/handlers/storage.go
@@ -296,6 +296,7 @@ func getDeffattedStorage(c context.Context, ctx *config.Context, address string,
 	filters := map[string]interface{}{
 		"destination_id": destination.ID,
 		"status":         types.OperationStatusApplied,
+		"last_action":    destination.LastAction,
 	}
 	if level > 0 {
 		filters["level"] = level

--- a/internal/parsers/storage/babylon.go
+++ b/internal/parsers/storage/babylon.go
@@ -84,6 +84,7 @@ func (b *Babylon) initPointersTypes(ctx context.Context, result *noderpc.Operati
 	operaiton, err := b.operations.Last(ctx, map[string]interface{}{
 		"destination_id": account.ID,
 		"status":         types.OperationStatusApplied,
+		"last_action":    account.LastAction,
 	}, 0)
 	if err != nil {
 		return err

--- a/internal/parsers/storage/lazy_babylon.go
+++ b/internal/parsers/storage/lazy_babylon.go
@@ -86,6 +86,7 @@ func (b *LazyBabylon) initPointersTypes(ctx context.Context, result *noderpc.Ope
 	operaiton, err := b.operations.Last(ctx, map[string]interface{}{
 		"destination_id": account.ID,
 		"status":         types.OperationStatusApplied,
+		"last_action":    account.LastAction,
 	}, 0)
 	if err != nil {
 		return err

--- a/internal/postgres/core/scopes.go
+++ b/internal/postgres/core/scopes.go
@@ -54,7 +54,7 @@ func (tf TimestampFilter) Apply(q *bun.SelectQuery) *bun.SelectQuery {
 		q = q.Where("timestamp > ?", tf.Gt)
 	}
 	if !tf.Gte.IsZero() {
-		q = q.Where("timestamp >- ?", tf.Gte)
+		q = q.Where("timestamp >= ?", tf.Gte)
 	}
 	if !tf.Lt.IsZero() {
 		q = q.Where("timestamp < ?", tf.Lt)

--- a/internal/postgres/operation/storage.go
+++ b/internal/postgres/operation/storage.go
@@ -23,12 +23,20 @@ func NewStorage(es *core.Postgres) *Storage {
 	return &Storage{es}
 }
 
-// Last - get last operation by `filters` with not empty deffated_storage
+// Last - get last operation by `filters` with not empty deffated_storage.
 func (storage *Storage) Last(ctx context.Context, filters map[string]interface{}, lastID int64) (operation.Operation, error) {
 	var (
 		current = time.Now()
 		endTime = consts.BeginningOfTime
 	)
+
+	var lastAction time.Time
+	if val, ok := filters["last_action"]; ok {
+		delete(filters, "last_action")
+		if ts, ok := val.(time.Time); ok {
+			lastAction = ts
+		}
+	}
 
 	if val, ok := filters["timestamp"]; ok {
 		if tf, ok := val.(core.TimestampFilter); ok {
@@ -48,6 +56,12 @@ func (storage *Storage) Last(ctx context.Context, filters map[string]interface{}
 		}
 	}
 
+	var tryEquality bool
+	if !lastAction.IsZero() {
+		current = lastAction
+		tryEquality = true
+	}
+
 	for current.After(endTime) {
 		query := storage.DB.NewSelect().Model((*operation.Operation)(nil)).
 			Where("deffated_storage is not null").
@@ -62,10 +76,15 @@ func (storage *Storage) Last(ctx context.Context, filters map[string]interface{}
 			}
 		}
 
-		lowCurrent := current.AddDate(0, -3, 0)
-		query.
-			Where("timestamp >= ?", lowCurrent).
-			Where("timestamp < ?", current)
+		next := current
+		if tryEquality {
+			query.Where("timestamp = ?", current)
+		} else {
+			next = current.AddDate(0, -3, 0)
+			query.
+				Where("timestamp >= ?", next).
+				Where("timestamp < ?", current)
+		}
 
 		if lastID > 0 {
 			query.Where("operation.id < ?", lastID)
@@ -87,7 +106,10 @@ func (storage *Storage) Last(ctx context.Context, filters map[string]interface{}
 			return ops[0], nil
 		}
 
-		current = lowCurrent
+		// on equality miss `next == current`: the loop re-runs the same
+		// upper bound as a regular window
+		tryEquality = false
+		current = next
 	}
 
 	return operation.Operation{}, sql.ErrNoRows


### PR DESCRIPTION
Operations.Last walked 3-month windows starting from time.Now(), so for long-inactive contracts it issued up to ~30 queries before finding the last operation. Callers now pass the account's last_action under a dedicated filter key: Last tries a cheap single-chunk timestamp equality query first and falls back to the window walk from that point.

Also fix a typo in TimestampFilter.Apply: `>-` -> `>=` for Gte.