### PR TITLE
Refactoring: iterators

### DIFF
--- a/cmd/api/validations/validations.go
+++ b/cmd/api/validations/validations.go
@@ -2,12 +2,12 @@ package validations
 
 import (
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/baking-bad/bcdhub/internal/bcd"
 	"github.com/baking-bad/bcdhub/internal/bcd/consts"
 	"github.com/baking-bad/bcdhub/internal/config"
-	"github.com/baking-bad/bcdhub/internal/helpers"
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/go-playground/validator/v10"
 )
@@ -90,7 +90,7 @@ func contractValidator() validator.Func {
 func networkValidator(networks []string) validator.Func {
 	return func(fl validator.FieldLevel) bool {
 		network := fl.Field().String()
-		return helpers.StringInArray(network, networks)
+		return slices.Contains(networks, network)
 	}
 }
 
@@ -110,12 +110,12 @@ func statusValidator() validator.Func {
 		status := fl.Field().String()
 		data := strings.Split(status, ",")
 		for i := range data {
-			if !helpers.StringInArray(data[i], []string{
+			if !slices.Contains([]string{
 				consts.Applied,
 				consts.Backtracked,
 				consts.Failed,
 				consts.Skipped,
-			}) {
+			}, data[i]) {
 				return false
 			}
 		}
@@ -126,22 +126,22 @@ func statusValidator() validator.Func {
 func faVersionValidator() validator.Func {
 	return func(fl validator.FieldLevel) bool {
 		version := fl.Field().String()
-		return helpers.StringInArray(version, []string{
+		return slices.Contains([]string{
 			consts.FA1Tag,
 			"fa12",
 			consts.FA2Tag,
-		})
+		}, version)
 	}
 }
 
 func fillTypeValidator() validator.Func {
 	return func(fl validator.FieldLevel) bool {
 		fillType := fl.Field().String()
-		return helpers.StringInArray(fillType, []string{
+		return slices.Contains([]string{
 			"empty",
 			"current",
 			"initial",
-		})
+		}, fillType)
 	}
 }
 

--- a/internal/bcd/ast/ast.go
+++ b/internal/bcd/ast/ast.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	stdJSON "encoding/json"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -401,10 +402,8 @@ func (a *TypedAst) EqualType(b *TypedAst) bool {
 func (a *TypedAst) FindBigMapByPtr() map[int64]*BigMap {
 	res := make(map[int64]*BigMap)
 	for i := range a.Nodes {
-		if m := a.Nodes[i].FindPointers(); m != nil {
-			for p, bm := range m {
-				res[p] = bm
-			}
+		if ptrs := a.Nodes[i].FindPointers(); ptrs != nil {
+			maps.Copy(res, ptrs)
 		}
 	}
 	return res

--- a/internal/bcd/ast/big_map.go
+++ b/internal/bcd/ast/big_map.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/baking-bad/bcdhub/internal/bcd/base"
@@ -42,7 +43,7 @@ func (m *BigMap) String() string {
 		s.WriteString(strings.Repeat(consts.DefaultIndent, m.Depth))
 		fmt.Fprintf(&s, "Ptr=%d\n", *m.Ptr)
 	case m.Data.Len() > 0:
-		_ = m.Data.Range(func(key, val Comparable) (bool, error) {
+		for key, val := range m.Data.All() {
 			s.WriteString(strings.Repeat(consts.DefaultIndent, m.Depth))
 			s.WriteByte('{')
 			s.WriteByte('\n')
@@ -53,8 +54,7 @@ func (m *BigMap) String() string {
 			s.WriteString(strings.Repeat(consts.DefaultIndent, m.Depth))
 			s.WriteByte('}')
 			s.WriteByte('\n')
-			return false, nil
-		})
+		}
 	default:
 		s.WriteString(strings.Repeat(consts.DefaultIndent, m.Depth))
 		s.WriteString(m.KeyType.String())
@@ -115,32 +115,32 @@ func (m *BigMap) ToMiguel() (*MiguelNode, error) {
 	switch {
 	case len(m.Data.keys) > 0:
 		node.Children = make([]*MiguelNode, 0)
-		handler := func(key, value Comparable) (bool, error) {
+
+		for key, value := range m.Data.All() {
+			if value == nil {
+				return nil, nil
+			}
+
 			keyNode := key.(Node)
 			keyChild, err := keyNode.ToMiguel()
 			if err != nil {
-				return true, err
-			}
-			if value == nil {
-				return false, nil
+				return nil, err
 			}
 
 			child, err := value.(Node).ToMiguel()
 			if err != nil {
-				return true, err
+				return nil, err
 			}
 
 			name, err := getMapKeyName(keyChild, keyNode)
 			if err != nil {
-				return true, err
+				return nil, err
 			}
 			child.Name = &name
 			node.Children = append(node.Children, child)
-
-			return false, nil
 		}
 
-		return node, m.Data.Range(handler)
+		return node, nil
 
 	case m.Ptr != nil:
 		node.Value = *m.Ptr
@@ -337,78 +337,71 @@ func (m *BigMap) Distinguish(x Distinguishable) (*MiguelNode, error) {
 	}
 	node.Children = make([]*MiguelNode, 0)
 
-	err := m.Data.Range(func(key, value Comparable) (bool, error) {
+	for key, value := range m.Data.All() {
 		keyNode := key.(Node)
 		keyChild, err := keyNode.ToMiguel()
 		if err != nil {
-			return true, err
+			return nil, err
 		}
 		name, err := getMapKeyName(keyChild, keyNode)
 		if err != nil {
-			return true, err
+			return nil, err
 		}
 
 		val, ok := second.Data.Get(key)
 		switch {
 		case val == nil && value == nil:
-			return false, nil
+			continue
 		case val == nil || !ok:
 			child, err := value.(Node).ToMiguel()
 			if err != nil {
-				return true, err
+				return nil, err
 			}
 			child.setDiffType(MiguelKindCreate)
 			child.Name = &name
 			node.Children = append(node.Children, child)
-			return false, nil
+
 		case value == nil && val != nil:
 			child, err := val.(Node).ToMiguel()
 			if err != nil {
-				return true, err
+				return nil, err
 			}
 			child.setDiffType(MiguelKindDelete)
 			child.Name = &name
 			node.Children = append(node.Children, child)
-			return false, nil
+
 		default:
 			child, err := value.(Node).Distinguish(val.(Node))
 			if err != nil {
-				return true, err
+				return nil, err
 			}
 
 			child.Name = &name
 			node.Children = append(node.Children, child)
-			return false, nil
 		}
-
-	})
-	if err != nil {
-		return nil, err
 	}
 
-	err = second.Data.Range(func(key, value Comparable) (bool, error) {
-		if _, ok := m.Data.Get(key); !ok {
-			child, err := value.(Node).ToMiguel()
-			if err != nil {
-				return true, err
-			}
-			keyNode := key.(Node)
-			keyChild, err := keyNode.ToMiguel()
-			if err != nil {
-				return true, err
-			}
-			child.setDiffType(MiguelKindDelete)
-			name, err := getMapKeyName(keyChild, keyNode)
-			if err != nil {
-				return true, err
-			}
-			child.Name = &name
-			node.Children = append(node.Children, child)
+	for key, value := range second.Data.All() {
+		if _, ok := m.Data.Get(key); ok {
+			continue
 		}
-		return false, nil
-	})
-	if err != nil {
-		return nil, err
+
+		child, err := value.(Node).ToMiguel()
+		if err != nil {
+			return nil, err
+		}
+		keyNode := key.(Node)
+		keyChild, err := keyNode.ToMiguel()
+		if err != nil {
+			return nil, err
+		}
+		child.setDiffType(MiguelKindDelete)
+		name, err := getMapKeyName(keyChild, keyNode)
+		if err != nil {
+			return nil, err
+		}
+		child.Name = &name
+		node.Children = append(node.Children, child)
 	}
 
 	return node, nil
@@ -476,32 +469,13 @@ func (m *BigMap) FindPointers() map[int64]*BigMap {
 		res[*m.Ptr] = m
 	}
 
-	if err := m.Data.Range(func(_, value Comparable) (bool, error) {
-		if value == nil {
-			return false, nil
-		}
+	for _, value := range m.Data.AllNotNil() {
 		node := value.(Node)
-		if m := node.FindPointers(); m != nil {
-			for k, v := range m {
-				res[k] = v
-			}
+		if ptrs := node.FindPointers(); ptrs != nil {
+			maps.Copy(res, ptrs)
 		}
-		return false, nil
-	}); err != nil {
-		return nil
 	}
 	return res
-}
-
-// Range -
-func (m *BigMap) Range(handler func(node Node) error) error {
-	if err := handler(m); err != nil {
-		return err
-	}
-	if err := m.KeyType.Range(handler); err != nil {
-		return err
-	}
-	return m.ValueType.Range(handler)
 }
 
 // GetJSONModel -
@@ -510,12 +484,11 @@ func (m *BigMap) GetJSONModel(model JSONModel) {
 		return
 	}
 	arr := make([]JSONModel, 0)
-	_ = m.Data.Range(func(key, value Comparable) (bool, error) {
+	for key, value := range m.Data.All() {
 		item := make(JSONModel)
 		key.(Node).GetJSONModel(item)
 		value.(Node).GetJSONModel(item)
 		arr = append(arr, item)
-		return false, nil
-	})
+	}
 	model[m.GetName()] = arr
 }

--- a/internal/bcd/ast/big_map.go
+++ b/internal/bcd/ast/big_map.go
@@ -116,11 +116,7 @@ func (m *BigMap) ToMiguel() (*MiguelNode, error) {
 	case len(m.Data.keys) > 0:
 		node.Children = make([]*MiguelNode, 0)
 
-		for key, value := range m.Data.All() {
-			if value == nil {
-				return nil, nil
-			}
-
+		for key, value := range m.Data.AllNotNil() {
 			keyNode := key.(Node)
 			keyChild, err := keyNode.ToMiguel()
 			if err != nil {

--- a/internal/bcd/ast/contract_interface.go
+++ b/internal/bcd/ast/contract_interface.go
@@ -1,6 +1,10 @@
 package ast
 
 import (
+	"iter"
+	"maps"
+	"slices"
+
 	"github.com/baking-bad/bcdhub/internal/bcd/ast/interfaces"
 	"github.com/baking-bad/bcdhub/internal/bcd/consts"
 )
@@ -22,32 +26,32 @@ type contractInterface struct {
 
 var interfaceTrees = map[string]contractInterface{}
 
+func collectMatchingTags(tree *TypedAst, tags iter.Seq[string]) []string {
+	return slices.Collect(func(yield func(string) bool) {
+		for tag := range tags {
+			if FindContractInterface(tree, tag) && !yield(tag) {
+				return
+			}
+		}
+	})
+}
+
 // FindContractInterfaces -
 func FindContractInterfaces(tree *TypedAst) []string {
 	if initInterfaceTrees() != nil {
 		return nil
 	}
-	tags := make([]string, 0)
-	for tag := range interfaceTrees {
-		if FindContractInterface(tree, tag) {
-			tags = append(tags, tag)
-		}
-	}
-	return tags
+	return collectMatchingTags(tree, maps.Keys(interfaceTrees))
 }
 
 func findViewContractInterfaces(tree *TypedAst) []string {
 	if initInterfaceTrees() != nil {
 		return nil
 	}
-	tags := make([]string, 0)
-	for _, tag := range []string{ContractTagViewNat, ContractTagViewAddress, ContractTagViewBalanceOf} {
-		if FindContractInterface(tree, tag) {
-			tags = append(tags, tag)
-		}
-	}
-
-	return tags
+	return collectMatchingTags(
+		tree,
+		slices.Values([]string{ContractTagViewNat, ContractTagViewAddress, ContractTagViewBalanceOf}),
+	)
 }
 
 // FindContractInterface -

--- a/internal/bcd/ast/default.go
+++ b/internal/bcd/ast/default.go
@@ -393,11 +393,6 @@ func (d *Default) FindPointers() map[int64]*BigMap {
 	return nil
 }
 
-// Range -
-func (d *Default) Range(handler func(node Node) error) error {
-	return handler(d)
-}
-
 // GetJSONModel -
 func (d *Default) GetJSONModel(model JSONModel) {
 	if model == nil {

--- a/internal/bcd/ast/docstring.go
+++ b/internal/bcd/ast/docstring.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/baking-bad/bcdhub/internal/bcd/consts"
@@ -69,13 +70,7 @@ func buildArrayDocs(nodes []Node) ([]Typedef, error) {
 }
 
 func isSimpleDocType(prim string) bool {
-	for _, t := range simpleTypes {
-		if prim == t {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(simpleTypes, prim)
 }
 
 func makeVarDocString(name string) string {

--- a/internal/bcd/ast/interface.go
+++ b/internal/bcd/ast/interface.go
@@ -28,7 +28,6 @@ type Type interface {
 	IsNamed() bool
 	IsPrim(prim string) bool
 	ParseType(node *base.Node, id *int) error
-	Range(handler func(node Node) error) error
 	ToJSONSchema() (*JSONSchema, error)
 }
 

--- a/internal/bcd/ast/list.go
+++ b/internal/bcd/ast/list.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/baking-bad/bcdhub/internal/bcd/base"
@@ -273,20 +274,10 @@ func (list *List) FindPointers() map[int64]*BigMap {
 	res := make(map[int64]*BigMap)
 	for i := range list.Data {
 		if b := list.Data[i].FindPointers(); b != nil {
-			for k, v := range b {
-				res[k] = v
-			}
+			maps.Copy(res, b)
 		}
 	}
 	return res
-}
-
-// Range -
-func (list *List) Range(handler func(node Node) error) error {
-	if err := handler(list); err != nil {
-		return err
-	}
-	return list.Type.Range(handler)
 }
 
 // GetJSONModel -

--- a/internal/bcd/ast/map.go
+++ b/internal/bcd/ast/map.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -35,7 +36,7 @@ func (m *Map) String() string {
 
 	s.WriteString(m.Default.String())
 	if m.Data.Len() > 0 {
-		_ = m.Data.Range(func(key, val Comparable) (bool, error) {
+		for key, val := range m.Data.All() {
 			s.WriteString(strings.Repeat(consts.DefaultIndent, m.Depth))
 			s.WriteByte('{')
 			s.WriteByte('\n')
@@ -46,8 +47,7 @@ func (m *Map) String() string {
 			s.WriteString(strings.Repeat(consts.DefaultIndent, m.Depth))
 			s.WriteByte('}')
 			s.WriteByte('\n')
-			return false, nil
-		})
+		}
 	} else {
 		s.WriteString(strings.Repeat(consts.DefaultIndent, m.Depth))
 		s.WriteString(m.KeyType.String())
@@ -102,30 +102,27 @@ func (m *Map) ToMiguel() (*MiguelNode, error) {
 
 	node.Children = make([]*MiguelNode, 0)
 
-	handler := func(key, value Comparable) (bool, error) {
+	for key, value := range m.Data.AllNotNil() {
 		keyNode := key.(Node)
 		keyChild, err := keyNode.ToMiguel()
 		if err != nil {
-			return true, err
+			return nil, err
 		}
-		if value != nil {
-			child, err := value.(Node).ToMiguel()
-			if err != nil {
-				return true, err
-			}
 
-			name, err := getMapKeyName(keyChild, keyNode)
-			if err != nil {
-				return true, err
-			}
-			child.Name = &name
-			node.Children = append(node.Children, child)
+		child, err := value.(Node).ToMiguel()
+		if err != nil {
+			return nil, err
 		}
-		return false, nil
+
+		name, err := getMapKeyName(keyChild, keyNode)
+		if err != nil {
+			return nil, err
+		}
+		child.Name = &name
+		node.Children = append(node.Children, child)
 	}
 
-	err = m.Data.Range(handler)
-	return node, err
+	return node, nil
 }
 
 // ToBaseNode -
@@ -201,15 +198,16 @@ func (m *Map) FromJSONSchema(data map[string]interface{}) error {
 
 // EnrichBigMap -
 func (m *Map) EnrichBigMap(bmd []*types.BigMapDiff) error {
-	return m.Data.Range(func(key, value Comparable) (bool, error) {
+	for key, value := range m.Data.All() {
 		if err := key.(Node).EnrichBigMap(bmd); err != nil {
-			return true, err
+			return err
 		}
 		if err := value.(Node).EnrichBigMap(bmd); err != nil {
-			return true, err
+			return err
 		}
-		return false, nil
-	})
+	}
+
+	return nil
 }
 
 // ToParameters -
@@ -285,64 +283,57 @@ func (m *Map) Distinguish(x Distinguishable) (*MiguelNode, error) {
 	node.Name = &name
 	node.Children = make([]*MiguelNode, 0)
 
-	err := m.Data.Range(func(key, value Comparable) (bool, error) {
+	for key, value := range m.Data.All() {
 		keyNode := key.(Node)
 		keyChild, err := keyNode.ToMiguel()
 		if err != nil {
-			return true, err
+			return nil, err
 		}
 		name, err := getMapKeyName(keyChild, keyNode)
 		if err != nil {
-			return true, err
+			return nil, err
 		}
 
 		val, ok := second.Data.Get(key)
 		if !ok {
 			child, err := value.(Node).ToMiguel()
 			if err != nil {
-				return true, err
+				return nil, err
 			}
 			child.setDiffType(MiguelKindCreate)
 			child.Name = &name
 			node.Children = append(node.Children, child)
-			return false, nil
+			continue
 		}
 
 		child, err := value.(Node).Distinguish(val.(Node))
 		if err != nil {
-			return true, err
+			return nil, err
 		}
 		child.Name = &name
 		node.Children = append(node.Children, child)
-		return false, nil
-	})
-	if err != nil {
-		return nil, err
 	}
 
-	err = second.Data.Range(func(key, value Comparable) (bool, error) {
-		if _, ok := m.Data.Get(key); !ok {
-			child, err := value.(Node).ToMiguel()
-			if err != nil {
-				return true, err
-			}
-			keyNode := key.(Node)
-			keyChild, err := keyNode.ToMiguel()
-			if err != nil {
-				return true, err
-			}
-			name, err := getMapKeyName(keyChild, keyNode)
-			if err != nil {
-				return true, err
-			}
-			child.setDiffType(MiguelKindDelete)
-			child.Name = &name
-			node.Children = append(node.Children, child)
+	for key, value := range second.Data.All() {
+		if _, ok := m.Data.Get(key); ok {
+			continue
 		}
-		return false, nil
-	})
-	if err != nil {
-		return nil, err
+		child, err := value.(Node).ToMiguel()
+		if err != nil {
+			return nil, err
+		}
+		keyNode := key.(Node)
+		keyChild, err := keyNode.ToMiguel()
+		if err != nil {
+			return nil, err
+		}
+		name, err := getMapKeyName(keyChild, keyNode)
+		if err != nil {
+			return nil, err
+		}
+		child.setDiffType(MiguelKindDelete)
+		child.Name = &name
+		node.Children = append(node.Children, child)
 	}
 
 	return node, nil
@@ -437,29 +428,13 @@ func getMapKeyName(node *MiguelNode, keyNode Node) (s string, err error) {
 // FindPointers -
 func (m *Map) FindPointers() map[int64]*BigMap {
 	res := make(map[int64]*BigMap)
-	if err := m.Data.Range(func(_, value Comparable) (bool, error) {
+	for _, value := range m.Data.All() {
 		node := value.(Node)
-		if m := node.FindPointers(); m != nil {
-			for k, v := range m {
-				res[k] = v
-			}
+		if ptrs := node.FindPointers(); ptrs != nil {
+			maps.Copy(res, ptrs)
 		}
-		return false, nil
-	}); err != nil {
-		return nil
 	}
 	return res
-}
-
-// Range -
-func (m *Map) Range(handler func(node Node) error) error {
-	if err := handler(m); err != nil {
-		return err
-	}
-	if err := m.KeyType.Range(handler); err != nil {
-		return err
-	}
-	return m.ValueType.Range(handler)
 }
 
 // GetJSONModel -
@@ -468,12 +443,11 @@ func (m *Map) GetJSONModel(model JSONModel) {
 		return
 	}
 	arr := make([]JSONModel, 0)
-	_ = m.Data.Range(func(key, value Comparable) (bool, error) {
+	for key, value := range m.Data.All() {
 		item := make(JSONModel)
 		key.(Node).GetJSONModel(item)
 		value.(Node).GetJSONModel(item)
 		arr = append(arr, item)
-		return false, nil
-	})
+	}
 	model[m.GetName()] = arr
 }

--- a/internal/bcd/ast/node.go
+++ b/internal/bcd/ast/node.go
@@ -102,16 +102,16 @@ func mapToBaseNodes(data *OrderedMap, optimized bool) (*base.Node, error) {
 	node.Prim = consts.PrimArray
 	node.Args = make([]*base.Node, 0)
 
-	err := data.Range(func(key, value Comparable) (bool, error) {
+	for key, value := range data.All() {
 		keyNode, err := key.(Node).ToBaseNode(optimized)
 		if err != nil {
-			return true, err
+			return nil, err
 		}
 		var valueNode *base.Node
 		if value != nil {
 			valueNode, err = value.(Node).ToBaseNode(optimized)
 			if err != nil {
-				return true, err
+				return nil, err
 			}
 		}
 		node.Args = append(node.Args, &base.Node{
@@ -120,9 +120,8 @@ func mapToBaseNodes(data *OrderedMap, optimized bool) (*base.Node, error) {
 				keyNode, valueNode,
 			},
 		})
-		return false, nil
-	})
-	return node, err
+	}
+	return node, nil
 }
 
 func arrayToBaseNode(data []Node, optimized bool) (*base.Node, error) {

--- a/internal/bcd/ast/option.go
+++ b/internal/bcd/ast/option.go
@@ -373,14 +373,6 @@ func (opt *Option) FindPointers() map[int64]*BigMap {
 	return nil
 }
 
-// Range -
-func (opt *Option) Range(handler func(node Node) error) error {
-	if opt.Value == consts.Some {
-		return opt.Type.Range(handler)
-	}
-	return nil
-}
-
 // GetJSONModel -
 func (opt *Option) GetJSONModel(model JSONModel) {
 	if model == nil {

--- a/internal/bcd/ast/or.go
+++ b/internal/bcd/ast/or.go
@@ -475,14 +475,6 @@ func (or *Or) FindPointers() map[int64]*BigMap {
 	return nil
 }
 
-// Range -
-func (or *Or) Range(handler func(node Node) error) error {
-	if err := or.LeftType.Range(handler); err != nil {
-		return err
-	}
-	return or.RightType.Range(handler)
-}
-
 // GetJSONModel -
 func (or *Or) GetJSONModel(model JSONModel) {
 	if model == nil {

--- a/internal/bcd/ast/ordered_map.go
+++ b/internal/bcd/ast/ordered_map.go
@@ -23,8 +23,8 @@ func NewOrderedMap() *OrderedMap {
 
 // Get -
 func (m *OrderedMap) Get(key Comparable) (Comparable, bool) {
-	defer m.lock.Unlock()
 	m.lock.Lock()
+	defer m.lock.Unlock()
 
 	for k, v := range m.values {
 		ok, err := key.Compare(k)
@@ -40,8 +40,8 @@ func (m *OrderedMap) Get(key Comparable) (Comparable, bool) {
 }
 
 func (m *OrderedMap) set(key, value Comparable) bool {
-	defer m.lock.Unlock()
 	m.lock.Lock()
+	defer m.lock.Unlock()
 
 	for k := range m.values {
 		ok, err := key.Compare(k)
@@ -63,8 +63,9 @@ func (m *OrderedMap) Add(key, value Comparable) error {
 		return nil
 	}
 
-	defer m.lock.Unlock()
 	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	m.values[key] = value
 	idx := -1
 	for i := range m.keys {
@@ -94,8 +95,8 @@ func (m *OrderedMap) Remove(key Comparable) (Comparable, bool) {
 		return nil, false
 	}
 
-	defer m.lock.Unlock()
 	m.lock.Lock()
+	defer m.lock.Unlock()
 
 	for i := range m.keys {
 		res, err := m.keys[i].Compare(key)
@@ -114,6 +115,9 @@ func (m *OrderedMap) Remove(key Comparable) (Comparable, bool) {
 // All -
 func (m *OrderedMap) All() iter.Seq2[Comparable, Comparable] {
 	return func(yield func(x Comparable, y Comparable) bool) {
+		m.lock.Lock()
+		defer m.lock.Unlock()
+
 		for i := range m.keys {
 			if !yield(m.keys[i], m.values[m.keys[i]]) {
 				return
@@ -125,6 +129,9 @@ func (m *OrderedMap) All() iter.Seq2[Comparable, Comparable] {
 // AllNotNil -
 func (m *OrderedMap) AllNotNil() iter.Seq2[Comparable, Comparable] {
 	return func(yield func(x Comparable, y Comparable) bool) {
+		m.lock.Lock()
+		defer m.lock.Unlock()
+
 		for i := range m.keys {
 			if m.values[m.keys[i]] == nil {
 				continue

--- a/internal/bcd/ast/ordered_map.go
+++ b/internal/bcd/ast/ordered_map.go
@@ -1,6 +1,9 @@
 package ast
 
-import "sync"
+import (
+	"iter"
+	"sync"
+)
 
 // OrderedMap -
 type OrderedMap struct {
@@ -108,18 +111,29 @@ func (m *OrderedMap) Remove(key Comparable) (Comparable, bool) {
 	return nil, false
 }
 
-// Range -
-func (m *OrderedMap) Range(handler func(key, value Comparable) (bool, error)) error {
-	defer m.lock.Unlock()
-	m.lock.Lock()
-
-	for i := range m.keys {
-		isBreak, err := handler(m.keys[i], m.values[m.keys[i]])
-		if err != nil || isBreak {
-			return err
+// All -
+func (m *OrderedMap) All() iter.Seq2[Comparable, Comparable] {
+	return func(yield func(x Comparable, y Comparable) bool) {
+		for i := range m.keys {
+			if !yield(m.keys[i], m.values[m.keys[i]]) {
+				return
+			}
 		}
 	}
-	return nil
+}
+
+// AllNotNil -
+func (m *OrderedMap) AllNotNil() iter.Seq2[Comparable, Comparable] {
+	return func(yield func(x Comparable, y Comparable) bool) {
+		for i := range m.keys {
+			if m.values[m.keys[i]] == nil {
+				continue
+			}
+			if !yield(m.keys[i], m.values[m.keys[i]]) {
+				return
+			}
+		}
+	}
 }
 
 // Len -

--- a/internal/bcd/ast/ordered_map_test.go
+++ b/internal/bcd/ast/ordered_map_test.go
@@ -81,9 +81,9 @@ func TestOrderedMap_Add(t *testing.T) {
 
 			require.Equal(t, tt.lengthAfterRemove, m.Len())
 
-			_ = m.Range(func(key, value Comparable) (bool, error) {
-				return false, nil
-			})
+			for key := range m.All() {
+				require.NotNil(t, key)
+			}
 		})
 	}
 }

--- a/internal/bcd/ast/pair.go
+++ b/internal/bcd/ast/pair.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"bytes"
+	"maps"
 	"strings"
 
 	"github.com/baking-bad/bcdhub/internal/bcd/base"
@@ -386,25 +387,10 @@ func (p *Pair) FindPointers() map[int64]*BigMap {
 	res := make(map[int64]*BigMap)
 	for i := range p.Args {
 		if b := p.Args[i].FindPointers(); b != nil {
-			for k, v := range b {
-				res[k] = v
-			}
+			maps.Copy(res, b)
 		}
 	}
 	return res
-}
-
-// Range -
-func (p *Pair) Range(handler func(node Node) error) error {
-	if err := handler(p); err != nil {
-		return err
-	}
-	for i := range p.Args {
-		if err := p.Args[i].Range(handler); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // GetJSONModel -

--- a/internal/bcd/ast/parameter_builder.go
+++ b/internal/bcd/ast/parameter_builder.go
@@ -44,23 +44,19 @@ func buildMapParameters(data *OrderedMap) ([]byte, error) {
 		return nil, err
 	}
 
-	err := data.Range(func(key, value Comparable) (bool, error) {
+	for key, value := range data.All() {
 		if builder.Len() != 1 {
 			if err := builder.WriteByte(','); err != nil {
-				return true, err
+				return nil, err
 			}
 		}
 		b, err := buildMapItemParameters(key.(Node), value.(Node))
 		if err != nil {
-			return true, err
+			return nil, err
 		}
 		if _, err := builder.Write(b); err != nil {
-			return true, err
+			return nil, err
 		}
-		return false, nil
-	})
-	if err != nil {
-		return nil, err
 	}
 	if err := builder.WriteByte(']'); err != nil {
 		return nil, err

--- a/internal/bcd/ast/set.go
+++ b/internal/bcd/ast/set.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/baking-bad/bcdhub/internal/bcd/base"
@@ -271,20 +272,10 @@ func (set *Set) FindPointers() map[int64]*BigMap {
 	res := make(map[int64]*BigMap)
 	for i := range set.Data {
 		if b := set.Data[i].FindPointers(); b != nil {
-			for k, v := range b {
-				res[k] = v
-			}
+			maps.Copy(res, b)
 		}
 	}
 	return res
-}
-
-// Range -
-func (set *Set) Range(handler func(node Node) error) error {
-	if err := handler(set); err != nil {
-		return err
-	}
-	return set.Type.Range(handler)
 }
 
 // GetJSONModel -

--- a/internal/bcd/formatter/formatter.go
+++ b/internal/bcd/formatter/formatter.go
@@ -2,12 +2,11 @@ package formatter
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
-
-	"github.com/baking-bad/bcdhub/internal/helpers"
 )
 
 // DefLineSize -
@@ -16,18 +15,18 @@ const DefLineSize = 88
 // IsFramed -
 func IsFramed(n gjson.Result) bool {
 	prim := n.Get("prim").String()
-	if helpers.StringInArray(prim, []string{
+	if slices.Contains([]string{
 		"Pair", "Left", "Right", "Some",
 		"pair", "or", "option", "map", "big_map", "list", "set", "contract", "lambda",
 		"ticket", "sapling_state", "sapling_transaction",
-	}) {
+	}, prim) {
 		return true
-	} else if helpers.StringInArray(prim, []string{
+	} else if slices.Contains([]string{
 		"key", "unit", "signature", "operation",
 		"int", "nat", "string", "bytes", "mutez", "bool", "key_hash", "timestamp", "address",
 		"bls12_381_g1", "bls12_381_g2", "bls12_381_fr", "chain_id", "never",
 		"chest", "chest_key", "tx_rollup_l2_address",
-	}) {
+	}, prim) {
 		return n.Get("annots").Exists()
 	}
 	return false
@@ -52,9 +51,9 @@ func IsScript(n gjson.Result) bool {
 	}
 	for _, item := range n.Array() {
 		prim := item.Get("prim").String()
-		if !helpers.StringInArray(prim, []string{
+		if !slices.Contains([]string{
 			"parameter", "storage", "code",
-		}) {
+		}, prim) {
 			return false
 		}
 	}

--- a/internal/helpers/string.go
+++ b/internal/helpers/string.go
@@ -11,16 +11,6 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
-// StringInArray -
-func StringInArray(s string, arr []string) bool {
-	for i := range arr {
-		if arr[i] == s {
-			return true
-		}
-	}
-	return false
-}
-
 // GenerateID -
 func GenerateID() string {
 	return strings.ReplaceAll(uuid.New().String(), "-", "")

--- a/internal/parsers/storage/alpha.go
+++ b/internal/parsers/storage/alpha.go
@@ -63,15 +63,15 @@ func (a *Alpha) ParseOrigination(ctx context.Context, content noderpc.Operation,
 
 			operation.BigMapDiffs = make([]*bigmapdiff.BigMapDiff, 0)
 
-			if err := bigMap.Data.Range(func(key, value ast.Comparable) (bool, error) {
+			for key, value := range bigMap.Data.All() {
 				k := key.(ast.Node)
 				keyHash, err := ast.BigMapKeyHashFromNode(k)
 				if err != nil {
-					return false, err
+					return err
 				}
 				keyBytes, err := k.ToParameters()
 				if err != nil {
-					return false, err
+					return err
 				}
 
 				var valBytes []byte
@@ -79,7 +79,7 @@ func (a *Alpha) ParseOrigination(ctx context.Context, content noderpc.Operation,
 					v := value.(ast.Node)
 					valBytes, err = v.ToParameters()
 					if err != nil {
-						return false, err
+						return err
 					}
 				}
 
@@ -98,9 +98,6 @@ func (a *Alpha) ParseOrigination(ctx context.Context, content noderpc.Operation,
 				state := b.ToState()
 				state.Ptr = -1
 				store.AddBigMapStates(state)
-				return false, nil
-			}); err != nil {
-				return err
 			}
 
 			if len(operation.BigMapDiffs) > 0 {


### PR DESCRIPTION
## Summary
Modernizes iteration patterns across `internal/bcd/ast` and a few adjacent packages to use Go 1.23+ `iter.Seq`/`iter.Seq2` range-over-func and stdlib `slices`/`maps` helpers, removing several hand-rolled `Range(handler func(...) (bool, error))` methods and a local `StringInArray` helper.

## Changes
- `OrderedMap.Range` replaced with `All()` (all entries) and `AllNotNil()` (skips nil values), both implemented as `iter.Seq2[Comparable, Comparable]` and locked for the duration of iteration, matching the locking behavior of `Get`/`Add`/`Remove`.
- The `Range(handler func(node Node) error) error` method is dropped from the `Type`/`Node` interface and from all implementers (`BigMap`, `Map`, `List`, `Set`, `Pair`, `Or`, `Option`, `Default`) — it had no remaining callers.
- `BigMap`/`Map`/`Pair`/`List`/`Set` `FindPointers` now use `maps.Copy` instead of manual merge loops.
- `cmd/api/validations` and `internal/bcd/formatter` switch from `internal/helpers.StringInArray` to `slices.Contains`; `internal/helpers.StringInArray` is removed as it's now unused.
- `internal/bcd/ast/contract_interface.go`: `FindContractInterfaces`/`findViewContractInterfaces` refactored around a shared `collectMatchingTags` helper taking an `iter.Seq[string]`.
- `internal/parsers/storage/alpha.go`: `ParseOrigination`'s big-map-diff loop now ranges directly over `bigMap.Data.All()` instead of a `Range` callback.

## Why
Pure internal refactor — no behavior or API changes intended. Cleans up boilerplate `(bool, error)`-returning callback plumbing in favor of native range-over-func iterators now that the module targets Go 1.26.