### PR TITLE
Fix: TezosX applied origination of a non-existing contract

### DIFF
--- a/internal/noderpc/errors.go
+++ b/internal/noderpc/errors.go
@@ -75,4 +75,5 @@ func (e InvalidNodeResponse) Is(target error) bool {
 var (
 	ErrInvalidStatusCode = errors.New("invalid status code")
 	ErrNodeRPCError      = errors.New("node RPC error")
+	ErrNotFound          = errors.New("not found")
 )

--- a/internal/noderpc/rpc.go
+++ b/internal/noderpc/rpc.go
@@ -91,7 +91,7 @@ func (rpc *NodeRPC) checkStatusCode(r io.Reader, statusCode int, checkStatusCode
 	case statusCode == http.StatusOK:
 		return nil
 	case statusCode == http.StatusNotFound:
-		return errors.Errorf("%s: not found", uri)
+		return fmt.Errorf("%w: %s", ErrNotFound, uri)
 	case statusCode > http.StatusInternalServerError:
 		return NewNodeUnavailiableError(rpc.baseURL, statusCode)
 	case checkStatusCode:

--- a/internal/noderpc/rpc_test.go
+++ b/internal/noderpc/rpc_test.go
@@ -3,6 +3,7 @@ package noderpc
 import (
 	"context"
 	stdJSON "encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -26,6 +27,13 @@ func TestNodeRPC_checkStatusCode(t *testing.T) {
 			checkStatusCode: true,
 			wantErr:         true,
 			errString:       "404 page not found",
+		}, {
+			name:            "404 not found",
+			r:               strings.NewReader(""),
+			statusCode:      404,
+			checkStatusCode: true,
+			wantErr:         true,
+			errString:       "not found",
 		}, {
 			name:            "200",
 			r:               strings.NewReader(""),
@@ -63,6 +71,7 @@ func TestNodeRPC_checkStatusCode(t *testing.T) {
 			if err != nil {
 				require.ErrorContains(t, err, tt.errString)
 			}
+			require.Equal(t, tt.statusCode == 404, errors.Is(err, ErrNotFound))
 		})
 	}
 }

--- a/internal/parsers/operations/origination.go
+++ b/internal/parsers/operations/origination.go
@@ -2,13 +2,18 @@ package operations
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/baking-bad/bcdhub/internal/models/account"
 	"github.com/baking-bad/bcdhub/internal/models/operation"
 	"github.com/baking-bad/bcdhub/internal/models/types"
 	"github.com/baking-bad/bcdhub/internal/noderpc"
 	"github.com/baking-bad/bcdhub/internal/parsers"
+	"github.com/rs/zerolog/log"
 )
+
+var errContractNotOriginated = errors.New("contract is not originated")
 
 // Origination -
 type Origination struct {
@@ -65,16 +70,30 @@ func (p Origination) Parse(ctx context.Context, data noderpc.Operation, store pa
 
 	parseOperationResult(data, &origination, store)
 
+	if origination.IsApplied() {
+		switch err := p.appliedHandler(ctx, data, &origination, store); {
+		case err == nil:
+			store.AddAccounts(origination.Destination)
+		case errors.Is(err, errContractNotOriginated):
+			if len(origination.TicketUpdates) > 0 {
+				return fmt.Errorf("%w: %s, but its result contains %d ticket updates",
+					err, origination.Destination.Address, len(origination.TicketUpdates))
+			}
+
+			log.Warn().
+				Str("address", origination.Destination.Address).
+				Int64("block", origination.Level).
+				Msg("origination is applied but contract does not exist, marking as failed")
+			origination.Status = types.OperationStatusFailed
+			origination.AllocatedDestinationContract = false
+		default:
+			return err
+		}
+	}
+
 	origination.SetBurned(*p.protocol.Constants)
 
 	p.stackTrace.Add(origination)
-
-	if origination.IsApplied() {
-		if err := p.appliedHandler(ctx, data, &origination, store); err != nil {
-			return err
-		}
-		store.AddAccounts(origination.Destination)
-	}
 
 	store.AddOperations(&origination)
 	store.AddAccounts(
@@ -92,10 +111,16 @@ func (p Origination) appliedHandler(ctx context.Context, item noderpc.Operation,
 
 	if p.specific.NeedReceiveRawStorage {
 		rawStorage, err := p.ctx.RPC.GetScriptStorageRaw(ctx, origination.Destination.Address, origination.Level)
-		if err != nil {
+		switch {
+		case err == nil:
+			origination.DeffatedStorage = rawStorage
+		case errors.Is(err, noderpc.ErrNotFound) &&
+			len(item.Script) > 0 &&
+			origination.Destination.Address != "":
+			return errContractNotOriginated
+		default:
 			return err
 		}
-		origination.DeffatedStorage = rawStorage
 	}
 
 	if err := p.specific.ContractParser.Parse(ctx, origination, store); err != nil {

--- a/internal/parsers/operations/origination_test.go
+++ b/internal/parsers/operations/origination_test.go
@@ -1,0 +1,140 @@
+package operations
+
+import (
+	"context"
+	stdJSON "encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/baking-bad/bcdhub/internal/config"
+	"github.com/baking-bad/bcdhub/internal/models/protocol"
+	"github.com/baking-bad/bcdhub/internal/models/types"
+	"github.com/baking-bad/bcdhub/internal/noderpc"
+	"github.com/baking-bad/bcdhub/internal/parsers"
+	"github.com/baking-bad/bcdhub/internal/parsers/protocols"
+	"github.com/baking-bad/bcdhub/internal/parsers/stacktrace"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// notFoundRPCError - reproduces the error the node client returns on HTTP 404,
+// with the same wrapping as (*NodeRPC).parseResponse
+func notFoundRPCError(uri string) error {
+	return fmt.Errorf("%w (%s): %w", noderpc.ErrNodeRPCError, uri, fmt.Errorf("%w: %s", noderpc.ErrNotFound, uri))
+}
+
+func TestOrigination_Parse_scriptNotFound(t *testing.T) {
+	const address = "KT1MsTf9bEgjVBb94b2R4fodp45DXCa3q1kV"
+	const level = int64(243222)
+
+	ticketUpdates := []noderpc.TicketUpdate{
+		{
+			TicketToken: noderpc.TicketToken{
+				Ticketer:    address,
+				ContentType: stdJSON.RawMessage(`{"prim":"string"}`),
+				Content:     stdJSON.RawMessage(`{"string":"abc"}`),
+			},
+			Updates: []noderpc.TicketUpdateItem{
+				{Account: "tz1WrbkDrzKVqcGXkjw4Qk4fXkjXpAJuNP1j", Amount: "1"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		// script of the origination content
+		script        stdJSON.RawMessage
+		ticketUpdates []noderpc.TicketUpdate
+		storageErr    error
+		wantErr       bool
+		wantStatus    types.OperationStatus
+		wantAccount   bool
+	}{
+		{
+			name:        "applied origination of a phantom contract",
+			script:      stdJSON.RawMessage(`{"code":[],"storage":{"int":"0"}}`),
+			storageErr:  notFoundRPCError("chains/main/blocks/243222/context/contracts/" + address + "/script"),
+			wantStatus:  types.OperationStatusFailed,
+			wantAccount: false,
+		}, {
+			name:       "applied origination of a contract without script",
+			script:     nil,
+			storageErr: notFoundRPCError("chains/main/blocks/243222/context/contracts/" + address + "/script"),
+			wantErr:    true,
+		}, {
+			name:       "unrelated rpc error is not swallowed",
+			script:     stdJSON.RawMessage(`{"code":[],"storage":{"int":"0"}}`),
+			storageErr: noderpc.NewNodeUnavailiableError("node", 502),
+			wantErr:    true,
+		}, {
+			name:          "phantom contract with ticket updates in the result",
+			script:        stdJSON.RawMessage(`{"code":[],"storage":{"int":"0"}}`),
+			ticketUpdates: ticketUpdates,
+			storageErr:    notFoundRPCError("chains/main/blocks/243222/context/contracts/" + address + "/script"),
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			rpc := noderpc.NewMockINode(ctrl)
+			rpc.EXPECT().
+				GetScriptStorageRaw(gomock.Any(), address, level).
+				Return(nil, tt.storageErr).
+				Times(1)
+
+			balance := int64(0)
+			paidStorageSizeDiff := int64(100)
+
+			params := &ParseParams{
+				ctx:        &config.Context{RPC: rpc},
+				specific:   &protocols.Specific{NeedReceiveRawStorage: true},
+				stackTrace: stacktrace.New(),
+				head: noderpc.Header{
+					Level:     level,
+					Timestamp: time.Now(),
+				},
+				protocol: &protocol.Protocol{
+					Constants: &protocol.Constants{CostPerByte: 250},
+				},
+			}
+
+			data := noderpc.Operation{
+				Kind:    "origination",
+				Source:  "tz1WrbkDrzKVqcGXkjw4Qk4fXkjXpAJuNP1j",
+				Balance: &balance,
+				Script:  tt.script,
+				Result: &noderpc.OperationResult{
+					Status:              "applied",
+					Originated:          []string{address},
+					PaidStorageSizeDiff: &paidStorageSizeDiff,
+					TicketUpdates:       tt.ticketUpdates,
+				},
+			}
+
+			store := parsers.NewTestStore()
+			err := NewOrigination(params).Parse(context.Background(), data, store)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			require.Len(t, store.Operations, 1)
+			op := store.Operations[0]
+			require.Equal(t, tt.wantStatus, op.Status)
+			require.False(t, op.AllocatedDestinationContract)
+			require.EqualValues(t, 0, op.Burned)
+
+			// the contract does not exist, so neither a contract nor its account is stored
+			require.Empty(t, store.Contracts)
+			_, ok := store.Accounts[address]
+			require.Equal(t, tt.wantAccount, ok)
+		})
+	}
+}


### PR DESCRIPTION
The indexer hit an incident on the TezosX previewnet.

Contract `KT1MsTf9bEgjVBb94b2R4fodp45DXCa3q1kV` was originated in block 243222, but the origination operation in that block should have had the `failed` status.
The genuine applied origination happened 16 blocks later, in 243238.
As a result, the node returns 404 for the contract script at level 243222, the indexer cannot load it and gets stuck retrying the block.
