### PR TITLE
Fix: indexer concurrency and rollback bugs

### DIFF
--- a/cmd/indexer/indexer/indexer.go
+++ b/cmd/indexer/indexer/indexer.go
@@ -43,6 +43,7 @@ type BlockchainIndexer struct {
 
 	Network types.Network
 
+	fatal        chan error
 	refreshTimer chan time.Duration
 	blockTime    atomic.Int64
 
@@ -80,6 +81,7 @@ func NewBlockchainIndexer(ctx context.Context, cfg config.Config, network string
 		startLevel:   indexerConfig.ResolveStartLevel(),
 		isPeriodic:   indexerConfig.Periodic != nil,
 		refreshTimer: make(chan time.Duration, 10),
+		fatal:        make(chan error, 1),
 		g:            workerpool.NewGroup(),
 		hub:          hub,
 	}
@@ -207,6 +209,11 @@ func (bi *BlockchainIndexer) Start(ctx context.Context) {
 	defer helpers.LocalCatchPanicSentry(bi.hub)
 	localSentry := bi.hub
 
+	select {
+	case <-bi.fatal:
+	default:
+	}
+
 	bi.g.GoCtx(ctx, bi.indexBlock)
 
 	bi.receiver.Start(ctx)
@@ -250,6 +257,10 @@ func (bi *BlockchainIndexer) Start(ctx context.Context) {
 			// https://go.dev/ref/spec#Select_statements
 			log.Info().Str("network", bi.Network.String()).Msgf("Data will be updated every %.0f seconds", d.Seconds())
 			ticker.Reset(d)
+
+		case err := <-bi.fatal:
+			log.Err(err).Str("network", bi.Network.String()).Msg("indexer stopped: unrecoverable error")
+			return
 		}
 	}
 }
@@ -306,7 +317,15 @@ func (bi *BlockchainIndexer) indexBlock(ctx context.Context) {
 			for ok {
 				if bi.state.Level > 0 && block.Header.Predecessor != bi.state.Hash {
 					if err := bi.Rollback(ctx); err != nil {
-						log.Err(err).Msg("rollback")
+						log.Err(err).Str("network", bi.Network.String()).Msg("rollback")
+						if errors.Is(err, errDeepReorg) {
+							helpers.LocalCatchErrorSentry(bi.hub, err)
+							select {
+							case bi.fatal <- err:
+							default:
+							}
+							return
+						}
 					}
 				} else {
 					if err := bi.handleBlock(ctx, block); err != nil {
@@ -458,14 +477,17 @@ func (bi *BlockchainIndexer) Rollback(ctx context.Context) error {
 	return nil
 }
 
+var errDeepReorg = errors.New("reorg is deeper than local history")
+
 func (bi *BlockchainIndexer) getLastRollbackBlock(ctx context.Context) (int64, error) {
 	var lastLevel int64
 	level := bi.state.Level
 
 	for end := false; !end; level-- {
 		if level <= bi.startLevel {
-			return 0, errors.Errorf(
-				"reorg is deeper than local history: reached level %d, indexing starts at %d",
+			return 0, errors.Wrapf(
+				errDeepReorg,
+				"reached level %d, indexing starts at %d",
 				level, bi.startLevel,
 			)
 		}
@@ -579,7 +601,6 @@ func (bi *BlockchainIndexer) reinit(ctx context.Context, cfg config.Config, inde
 	log.Info().Str("network", bi.Network.String()).Msg("Creating indexer object...")
 	bi.receiver = NewReceiver(bi.RPC, 20, indexerConfig.ReceiverThreads)
 	bi.startLevel = indexerConfig.ResolveStartLevel()
-
-	bi.refreshTimer = make(chan time.Duration, 10)
+	bi.blocks = make(map[int64]*Block)
 	return bi.init(ctx, bi.StorageDB)
 }

--- a/cmd/indexer/indexer/indexer.go
+++ b/cmd/indexer/indexer/indexer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/baking-bad/bcdhub/internal/bcd"
@@ -40,10 +41,10 @@ type BlockchainIndexer struct {
 	currentProtocol protocol.Protocol
 	blocks          map[int64]*Block
 
-	updateTicker *time.Ticker
-	Network      types.Network
+	Network types.Network
 
-	refreshTimer chan struct{}
+	refreshTimer chan time.Duration
+	blockTime    atomic.Int64
 
 	startLevel  int64
 	isPeriodic  bool
@@ -78,7 +79,7 @@ func NewBlockchainIndexer(ctx context.Context, cfg config.Config, network string
 		Network:      networkType,
 		startLevel:   indexerConfig.ResolveStartLevel(),
 		isPeriodic:   indexerConfig.Periodic != nil,
-		refreshTimer: make(chan struct{}, 10),
+		refreshTimer: make(chan time.Duration, 10),
 		g:            workerpool.NewGroup(),
 		hub:          hub,
 	}
@@ -94,7 +95,6 @@ func NewBlockchainIndexer(ctx context.Context, cfg config.Config, network string
 func (bi *BlockchainIndexer) Close() error {
 	bi.g.Wait()
 
-	close(bi.refreshTimer)
 	if err := bi.receiver.Close(); err != nil {
 		log.Err(err).Msg("closing receiver")
 	}
@@ -158,6 +158,7 @@ func (bi *BlockchainIndexer) init(ctx context.Context, db *core.Postgres) error 
 	}
 
 	bi.currentProtocol = currentProtocol
+	bi.blockTime.Store(currentProtocol.TimeBetweenBlocks * int64(time.Second))
 	log.Info().Str("network", bi.Network.String()).Msgf("Current network protocol: %s", currentProtocol.Hash)
 
 	for {
@@ -218,12 +219,16 @@ func (bi *BlockchainIndexer) Start(ctx context.Context) {
 	}
 
 	everySecond := false
-	bi.setUpdateTicker(0)
+	duration := bi.tickerDuration(0)
+	log.Info().Str("network", bi.Network.String()).Msgf("Data will be updated every %.0f seconds", duration.Seconds())
+	ticker := time.NewTicker(duration)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-bi.updateTicker.C:
+		case <-ticker.C:
 			if err := bi.process(ctx); err != nil {
 				if errors.Is(err, errSameLevel) {
 					if !everySecond {
@@ -239,9 +244,12 @@ func (bi *BlockchainIndexer) Start(ctx context.Context) {
 				everySecond = false
 				bi.setUpdateTicker(0)
 			}
-		case <-bi.refreshTimer:
-			// do nothing. refreshTimer event is for update select statement after Ticker update
+		case d := <-bi.refreshTimer:
+			// the ticker is reset here, in its owning goroutine, so that the select
+			// statement picks up the new interval
 			// https://go.dev/ref/spec#Select_statements
+			log.Info().Str("network", bi.Network.String()).Msgf("Data will be updated every %.0f seconds", d.Seconds())
+			ticker.Reset(d)
 		}
 	}
 }
@@ -260,22 +268,26 @@ func (bi *BlockchainIndexer) reportProcessError(hub *sentry.Hub, err error) {
 	helpers.LocalCatchErrorSentry(hub, err)
 }
 
+// tickerDuration returns the interval between process calls: the current protocol's
+// time between blocks when seconds is 0, the given number of seconds otherwise.
+func (bi *BlockchainIndexer) tickerDuration(seconds int) time.Duration {
+	if seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if duration := time.Duration(bi.blockTime.Load()); duration > 0 {
+		return duration
+	}
+	return 10 * time.Second
+}
+
+// setUpdateTicker asks the Start loop to change its interval. It is safe to call from
+// any goroutine: the ticker itself is never touched outside of Start.
 func (bi *BlockchainIndexer) setUpdateTicker(seconds int) {
-	var duration time.Duration
-	if seconds == 0 {
-		duration = time.Duration(bi.currentProtocol.TimeBetweenBlocks) * time.Second
-		if duration.Microseconds() <= 0 {
-			duration = 10 * time.Second
-		}
-	} else {
-		duration = time.Duration(seconds) * time.Second
+	select {
+	case bi.refreshTimer <- bi.tickerDuration(seconds):
+	default:
+		log.Warn().Str("network", bi.Network.String()).Msg("ticker update is dropped: refresh queue is full")
 	}
-	if bi.updateTicker != nil {
-		bi.updateTicker.Stop()
-	}
-	log.Info().Str("network", bi.Network.String()).Msgf("Data will be updated every %.0f seconds", duration.Seconds())
-	bi.updateTicker = time.NewTicker(duration)
-	bi.refreshTimer <- struct{}{}
 }
 
 func (bi *BlockchainIndexer) indexBlock(ctx context.Context) {
@@ -404,6 +416,7 @@ func (bi *BlockchainIndexer) migrate(ctx context.Context, head noderpc.Header) e
 	}
 
 	bi.currentProtocol = newProto
+	bi.blockTime.Store(newProto.TimeBetweenBlocks * int64(time.Second))
 
 	if err := tx.Commit(); err != nil {
 		return err
@@ -450,6 +463,13 @@ func (bi *BlockchainIndexer) getLastRollbackBlock(ctx context.Context) (int64, e
 	level := bi.state.Level
 
 	for end := false; !end; level-- {
+		if level <= bi.startLevel {
+			return 0, errors.Errorf(
+				"reorg is deeper than local history: reached level %d, indexing starts at %d",
+				level, bi.startLevel,
+			)
+		}
+
 		headAtLevel, err := bi.RPC.GetHeader(ctx, level)
 		if err != nil {
 			return 0, err
@@ -560,6 +580,6 @@ func (bi *BlockchainIndexer) reinit(ctx context.Context, cfg config.Config, inde
 	bi.receiver = NewReceiver(bi.RPC, 20, indexerConfig.ReceiverThreads)
 	bi.startLevel = indexerConfig.ResolveStartLevel()
 
-	bi.refreshTimer = make(chan struct{}, 10)
+	bi.refreshTimer = make(chan time.Duration, 10)
 	return bi.init(ctx, bi.StorageDB)
 }

--- a/cmd/indexer/indexer/indexer_test.go
+++ b/cmd/indexer/indexer/indexer_test.go
@@ -65,3 +65,91 @@ func TestReportProcessError(t *testing.T) {
 		})
 	}
 }
+
+func TestTickerDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		// blockTime is the protocol's TimeBetweenBlocks in seconds, as stored by init/migrate
+		blockTime int64
+		seconds   int
+		want      time.Duration
+	}{
+		{
+			name:      "protocol time between blocks",
+			blockTime: 8,
+			seconds:   0,
+			want:      8 * time.Second,
+		},
+		{
+			name:      "explicit interval wins over protocol",
+			blockTime: 8,
+			seconds:   5,
+			want:      5 * time.Second,
+		},
+		{
+			name:      "fallback when protocol has no time between blocks",
+			blockTime: 0,
+			seconds:   0,
+			want:      10 * time.Second,
+		},
+		{
+			name:      "explicit interval without protocol",
+			blockTime: 0,
+			seconds:   5,
+			want:      5 * time.Second,
+		},
+		{
+			name:      "protocol time between blocks after migration",
+			blockTime: 15,
+			seconds:   0,
+			want:      15 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bi := &BlockchainIndexer{Network: types.Mainnet}
+			bi.blockTime.Store(tt.blockTime * int64(time.Second))
+
+			require.Equal(t, tt.want, bi.tickerDuration(tt.seconds))
+		})
+	}
+}
+
+func TestSetUpdateTicker(t *testing.T) {
+	t.Run("delivers the requested interval to the Start loop", func(t *testing.T) {
+		bi := &BlockchainIndexer{
+			Network:      types.Mainnet,
+			refreshTimer: make(chan time.Duration, 10),
+		}
+		bi.blockTime.Store(8 * int64(time.Second))
+
+		bi.setUpdateTicker(5)
+		bi.setUpdateTicker(0)
+
+		require.Equal(t, 5*time.Second, <-bi.refreshTimer)
+		require.Equal(t, 8*time.Second, <-bi.refreshTimer)
+	})
+
+	t.Run("drops the update instead of blocking when the queue is full", func(t *testing.T) {
+		bi := &BlockchainIndexer{
+			Network:      types.Mainnet,
+			refreshTimer: make(chan time.Duration, 1),
+		}
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			bi.setUpdateTicker(5)
+			bi.setUpdateTicker(5)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("setUpdateTicker blocked on a full refreshTimer")
+		}
+
+		require.Len(t, bi.refreshTimer, 1)
+	})
+}

--- a/cmd/indexer/indexer/periodic.go
+++ b/cmd/indexer/indexer/periodic.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/baking-bad/bcdhub/internal/config"
@@ -19,6 +20,7 @@ type PeriodicIndexer struct {
 	indexerCancel context.CancelFunc
 
 	cfg         config.Config
+	mx          sync.Mutex
 	indexerCfg  config.IndexerConfig
 	indexerDone chan struct{}
 
@@ -39,10 +41,9 @@ func NewPeriodicIndexer(
 	}
 
 	p := &PeriodicIndexer{
-		cfg:         cfg,
-		indexerCfg:  indexerCfg,
-		g:           g,
-		indexerDone: make(chan struct{}),
+		cfg:        cfg,
+		indexerCfg: indexerCfg,
+		g:          g,
 	}
 
 	worker, err := periodic.New(*indexerCfg.Periodic, types.NewNetwork(network), p.handleUrlChanged)
@@ -74,15 +75,24 @@ func NewPeriodicIndexer(
 
 // Start -
 func (p *PeriodicIndexer) Start(ctx context.Context) {
-	indexerCtx, indexerCancel := context.WithCancel(ctx)
-	p.indexerCancel = indexerCancel
-	p.runIndexer(indexerCtx)
+	p.runIndexer(ctx)
 }
 
-// runIndexer runs the indexer loop and signals its exit via indexerDone.
+// runIndexer spawns the indexer loop in the worker group and records its cancel func
+// and exit channel, so that handleUrlChanged can stop it and wait for it to finish.
 func (p *PeriodicIndexer) runIndexer(ctx context.Context) {
-	defer close(p.indexerDone)
-	p.indexer.Start(ctx)
+	done := make(chan struct{})
+	indexerCtx, indexerCancel := context.WithCancel(ctx)
+
+	p.mx.Lock()
+	p.indexerDone = done
+	p.indexerCancel = indexerCancel
+	p.mx.Unlock()
+
+	p.g.GoCtx(indexerCtx, func(ctx context.Context) {
+		defer close(done)
+		p.indexer.Start(ctx)
+	})
 }
 
 // Close -
@@ -105,35 +115,20 @@ func (p *PeriodicIndexer) Rollback(ctx context.Context) error {
 
 func (p *PeriodicIndexer) handleUrlChanged(ctx context.Context, network, url string) error {
 	log.Warn().Str("network", network).Str("url", url).Msg("cancelling indexer due to URL changing...")
-	if p.indexerCancel == nil {
-		return errors.New("indexer cancel func is nil")
-	}
 	if p.indexer == nil {
 		return errors.New("indexer is nil")
 	}
-	p.indexerCancel()
-
-	select {
-	case <-p.indexerDone:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-
-	if err := p.indexer.Close(); err != nil {
+	if err := p.stopIndexer(ctx); err != nil {
 		return err
 	}
 
 	setUrlToConfig(&p.cfg, url, network)
 
-	p.indexerDone = make(chan struct{})
 	if err := p.indexer.reinit(ctx, p.cfg, p.indexerCfg); err != nil {
 		return err
 	}
 
-	indexerCtx, indexerCancel := context.WithCancel(ctx)
-	p.indexerCancel = indexerCancel
-	p.g.GoCtx(indexerCtx, p.runIndexer)
-
+	p.runIndexer(ctx)
 	return nil
 }
 
@@ -141,5 +136,24 @@ func setUrlToConfig(cfg *config.Config, url string, network string) {
 	if value, ok := cfg.RPC[network]; ok {
 		value.URI = url
 		cfg.RPC[network] = value
+	}
+}
+
+// stopIndexer cancels the running indexer loop and waits for its exit.
+func (p *PeriodicIndexer) stopIndexer(ctx context.Context) error {
+	p.mx.Lock()
+	cancel, done := p.indexerCancel, p.indexerDone
+	p.mx.Unlock()
+
+	if cancel == nil {
+		return errors.New("indexer is not running")
+	}
+	cancel()
+
+	select {
+	case <-done:
+		return p.indexer.Close()
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }

--- a/cmd/indexer/indexer/periodic.go
+++ b/cmd/indexer/indexer/periodic.go
@@ -18,8 +18,9 @@ type PeriodicIndexer struct {
 	indexer       *BlockchainIndexer
 	indexerCancel context.CancelFunc
 
-	cfg        config.Config
-	indexerCfg config.IndexerConfig
+	cfg         config.Config
+	indexerCfg  config.IndexerConfig
+	indexerDone chan struct{}
 
 	worker *periodic.Worker
 	g      workerpool.Group
@@ -38,9 +39,10 @@ func NewPeriodicIndexer(
 	}
 
 	p := &PeriodicIndexer{
-		cfg:        cfg,
-		indexerCfg: indexerCfg,
-		g:          g,
+		cfg:         cfg,
+		indexerCfg:  indexerCfg,
+		g:           g,
+		indexerDone: make(chan struct{}),
 	}
 
 	worker, err := periodic.New(*indexerCfg.Periodic, types.NewNetwork(network), p.handleUrlChanged)
@@ -74,7 +76,13 @@ func NewPeriodicIndexer(
 func (p *PeriodicIndexer) Start(ctx context.Context) {
 	indexerCtx, indexerCancel := context.WithCancel(ctx)
 	p.indexerCancel = indexerCancel
-	p.indexer.Start(indexerCtx)
+	p.runIndexer(indexerCtx)
+}
+
+// runIndexer runs the indexer loop and signals its exit via indexerDone.
+func (p *PeriodicIndexer) runIndexer(ctx context.Context) {
+	defer close(p.indexerDone)
+	p.indexer.Start(ctx)
 }
 
 // Close -
@@ -105,19 +113,26 @@ func (p *PeriodicIndexer) handleUrlChanged(ctx context.Context, network, url str
 	}
 	p.indexerCancel()
 
+	select {
+	case <-p.indexerDone:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
 	if err := p.indexer.Close(); err != nil {
 		return err
 	}
 
 	setUrlToConfig(&p.cfg, url, network)
 
+	p.indexerDone = make(chan struct{})
 	if err := p.indexer.reinit(ctx, p.cfg, p.indexerCfg); err != nil {
 		return err
 	}
 
 	indexerCtx, indexerCancel := context.WithCancel(ctx)
 	p.indexerCancel = indexerCancel
-	p.g.GoCtx(indexerCtx, p.indexer.Start)
+	p.g.GoCtx(indexerCtx, p.runIndexer)
 
 	return nil
 }

--- a/cmd/indexer/indexer/rollback_test.go
+++ b/cmd/indexer/indexer/rollback_test.go
@@ -1,0 +1,154 @@
+package indexer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/baking-bad/bcdhub/internal/config"
+	"github.com/baking-bad/bcdhub/internal/models/block"
+	mockblock "github.com/baking-bad/bcdhub/internal/models/mock/block"
+	"github.com/baking-bad/bcdhub/internal/models/types"
+	"github.com/baking-bad/bcdhub/internal/noderpc"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetLastRollbackBlock(t *testing.T) {
+	errRPC := errors.New("node is unavailable")
+	errStorage := errors.New("no rows in result set")
+
+	tests := []struct {
+		name       string
+		startLevel int64
+		stateLevel int64
+		setup      func(rpc *noderpc.MockINode, blocks *mockblock.MockRepository)
+		want       int64
+		wantErr    error
+	}{
+		{
+			name:       "common ancestor one level below the head",
+			startLevel: 100,
+			stateLevel: 105,
+			setup: func(rpc *noderpc.MockINode, blocks *mockblock.MockRepository) {
+				rpc.EXPECT().GetHeader(gomock.Any(), int64(105)).
+					Return(noderpc.Header{Level: 105, Predecessor: "block_104"}, nil)
+				blocks.EXPECT().Get(gomock.Any(), int64(104)).
+					Return(block.Block{Level: 104, Hash: "block_104"}, nil)
+			},
+			want: 104,
+		},
+		{
+			name:       "walks down until predecessors match",
+			startLevel: 100,
+			stateLevel: 105,
+			setup: func(rpc *noderpc.MockINode, blocks *mockblock.MockRepository) {
+				rpc.EXPECT().GetHeader(gomock.Any(), int64(105)).
+					Return(noderpc.Header{Level: 105, Predecessor: "node_104"}, nil)
+				blocks.EXPECT().Get(gomock.Any(), int64(104)).
+					Return(block.Block{Level: 104, Hash: "orphan_104"}, nil)
+
+				rpc.EXPECT().GetHeader(gomock.Any(), int64(104)).
+					Return(noderpc.Header{Level: 104, Predecessor: "node_103"}, nil)
+				blocks.EXPECT().Get(gomock.Any(), int64(103)).
+					Return(block.Block{Level: 103, Hash: "orphan_103"}, nil)
+
+				rpc.EXPECT().GetHeader(gomock.Any(), int64(103)).
+					Return(noderpc.Header{Level: 103, Predecessor: "common_102"}, nil)
+				blocks.EXPECT().Get(gomock.Any(), int64(102)).
+					Return(block.Block{Level: 102, Hash: "common_102"}, nil)
+			},
+			want: 102,
+		},
+		{
+			// startLevel+1 must still be probed: it is the lowest level where
+			// Blocks.Get(level-1) can resolve against the locally indexed history.
+			name:       "common ancestor exactly at the start level",
+			startLevel: 100,
+			stateLevel: 101,
+			setup: func(rpc *noderpc.MockINode, blocks *mockblock.MockRepository) {
+				rpc.EXPECT().GetHeader(gomock.Any(), int64(101)).
+					Return(noderpc.Header{Level: 101, Predecessor: "block_100"}, nil)
+				blocks.EXPECT().Get(gomock.Any(), int64(100)).
+					Return(block.Block{Level: 100, Hash: "block_100"}, nil)
+			},
+			want: 100,
+		},
+		{
+			name:       "reorg deeper than the locally indexed history",
+			startLevel: 100,
+			stateLevel: 102,
+			setup: func(rpc *noderpc.MockINode, blocks *mockblock.MockRepository) {
+				rpc.EXPECT().GetHeader(gomock.Any(), int64(102)).
+					Return(noderpc.Header{Level: 102, Predecessor: "node_101"}, nil)
+				blocks.EXPECT().Get(gomock.Any(), int64(101)).
+					Return(block.Block{Level: 101, Hash: "orphan_101"}, nil)
+
+				rpc.EXPECT().GetHeader(gomock.Any(), int64(101)).
+					Return(noderpc.Header{Level: 101, Predecessor: "node_100"}, nil)
+				blocks.EXPECT().Get(gomock.Any(), int64(100)).
+					Return(block.Block{Level: 100, Hash: "orphan_100"}, nil)
+				// level 100 == startLevel: the walk stops instead of running past it
+			},
+			wantErr: errDeepReorg,
+		},
+		{
+			name:       "state is already at the start level",
+			startLevel: 100,
+			stateLevel: 100,
+			setup:      func(rpc *noderpc.MockINode, blocks *mockblock.MockRepository) {},
+			wantErr:    errDeepReorg,
+		},
+		{
+			name:       "rpc error is propagated",
+			startLevel: 100,
+			stateLevel: 105,
+			setup: func(rpc *noderpc.MockINode, blocks *mockblock.MockRepository) {
+				rpc.EXPECT().GetHeader(gomock.Any(), int64(105)).
+					Return(noderpc.Header{}, errRPC)
+			},
+			wantErr: errRPC,
+		},
+		{
+			name:       "storage error is propagated",
+			startLevel: 100,
+			stateLevel: 105,
+			setup: func(rpc *noderpc.MockINode, blocks *mockblock.MockRepository) {
+				rpc.EXPECT().GetHeader(gomock.Any(), int64(105)).
+					Return(noderpc.Header{Level: 105, Predecessor: "block_104"}, nil)
+				blocks.EXPECT().Get(gomock.Any(), int64(104)).
+					Return(block.Block{}, errStorage)
+			},
+			wantErr: errStorage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			rpc := noderpc.NewMockINode(ctrl)
+			blocks := mockblock.NewMockRepository(ctrl)
+			tt.setup(rpc, blocks)
+
+			bi := &BlockchainIndexer{
+				Context: &config.Context{
+					RPC:    rpc,
+					Blocks: blocks,
+				},
+				Network:    types.Mainnet,
+				startLevel: tt.startLevel,
+				state:      block.Block{Level: tt.stateLevel},
+			}
+
+			got, err := bi.getLastRollbackBlock(context.Background())
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Zero(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/periodic/general_worker.go
+++ b/internal/periodic/general_worker.go
@@ -3,6 +3,7 @@ package periodic
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/baking-bad/bcdhub/internal/teztnets"
@@ -12,11 +13,12 @@ import (
 
 // GeneralWorker -
 type GeneralWorker struct {
-	rpc      *teztnets.RPC
-	schedule string
-	cron     *cron.Cron
-	handler  ChangedHandler
-	urls     map[string]string
+	rpc       *teztnets.RPC
+	schedule  string
+	cron      *cron.Cron
+	handler   ChangedHandler
+	urls      map[string]string
+	isRunning atomic.Bool
 }
 
 // NewGeneralWorker -
@@ -71,6 +73,12 @@ func (w *GeneralWorker) Close() error {
 
 func (w *GeneralWorker) handleScheduleEvent(ctx context.Context) func() {
 	return func() {
+		if !w.isRunning.CompareAndSwap(false, true) {
+			log.Warn().Msg("periodic worker is already running")
+			return
+		}
+		defer w.isRunning.Store(false)
+
 		log.Info().Msg("trying to receive new rpc url")
 
 		changed, err := w.checkNetwork(ctx)

--- a/internal/periodic/general_worker.go
+++ b/internal/periodic/general_worker.go
@@ -2,7 +2,9 @@ package periodic
 
 import (
 	"context"
+	"maps"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -18,6 +20,7 @@ type GeneralWorker struct {
 	cron      *cron.Cron
 	handler   ChangedHandler
 	urls      map[string]string
+	mx        sync.RWMutex
 	isRunning atomic.Bool
 }
 
@@ -74,7 +77,7 @@ func (w *GeneralWorker) Close() error {
 func (w *GeneralWorker) handleScheduleEvent(ctx context.Context) func() {
 	return func() {
 		if !w.isRunning.CompareAndSwap(false, true) {
-			log.Warn().Msg("periodic worker is already running")
+			log.Debug().Msg("periodic worker is already running")
 			return
 		}
 		defer w.isRunning.Store(false)
@@ -124,15 +127,30 @@ func (w *GeneralWorker) checkNetwork(ctx context.Context) (bool, error) {
 		}
 
 		network := parts[0]
-		if current := w.urls[network]; current != data.RPCURL {
-			if err := w.handler(ctx, network, data.RPCURL); err != nil {
-				log.Err(err).Str("network", network).Msg("failed to apply new rpc url")
-			}
-			w.urls[network] = data.RPCURL
 
-			log.Info().Str("network", network).Str("url", data.RPCURL).Msg("new url was found")
-			changed = true
+		w.mx.RLock()
+		current := w.urls[network]
+		w.mx.RUnlock()
+
+		if current == data.RPCURL {
+			continue
 		}
+
+		// the handler re-points the service at the new node, so it must not run while
+		// the mutex that URLs() needs is held
+		if err := w.handler(ctx, network, data.RPCURL); err != nil {
+			// leave the stored url untouched so that the next poll retries the switch
+			// instead of silently dropping the network
+			log.Err(err).Str("network", network).Msg("failed to apply new rpc url")
+			continue
+		}
+
+		w.mx.Lock()
+		w.urls[network] = data.RPCURL
+		w.mx.Unlock()
+
+		log.Info().Str("network", network).Str("url", data.RPCURL).Msg("new url was found")
+		changed = true
 	}
 
 	return changed, nil
@@ -140,5 +158,9 @@ func (w *GeneralWorker) checkNetwork(ctx context.Context) (bool, error) {
 
 // URLs -
 func (w *GeneralWorker) URLs() map[string]string {
-	return w.urls
+	w.mx.RLock()
+	defer w.mx.RUnlock()
+	urls := make(map[string]string, len(w.urls))
+	maps.Copy(urls, w.urls)
+	return urls
 }

--- a/internal/periodic/worker.go
+++ b/internal/periodic/worker.go
@@ -3,6 +3,7 @@ package periodic
 import (
 	"context"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,6 +20,7 @@ type Worker struct {
 	schedule   string
 	cron       *cron.Cron
 	currentUrl string
+	mx         sync.RWMutex
 	handler    ChangedHandler
 	isRunning  atomic.Bool
 }
@@ -79,7 +81,7 @@ func (w *Worker) Close() error {
 func (w *Worker) handleScheduleEvent(ctx context.Context) func() {
 	return func() {
 		if !w.isRunning.CompareAndSwap(false, true) {
-			log.Warn().Str("network", w.network.String()).Msg("periodic worker is already running")
+			log.Debug().Str("network", w.network.String()).Msg("periodic worker is already running")
 			return
 		}
 		defer w.isRunning.Store(false)
@@ -132,17 +134,28 @@ func (w *Worker) checkNetwork(ctx context.Context) (bool, error) {
 			continue
 		}
 
-		if w.currentUrl != data.RPCURL {
-			if w.currentUrl != "" {
-				if err := w.handler(ctx, w.network.String(), data.RPCURL); err != nil {
-					log.Err(err).Str("network", w.network.String()).Msg("failed to apply new rpc url")
-				}
-			}
-			w.currentUrl = data.RPCURL
-
-			log.Info().Str("network", parts[0]).Str("url", w.currentUrl).Msg("new url was found")
-			return true, nil
+		current := w.URL()
+		if current == data.RPCURL {
+			continue
 		}
+
+		// the handler tears the indexer down and re-initialises it, so it must not run
+		// while the mutex that URL() needs is held
+		if current != "" {
+			if err := w.handler(ctx, w.network.String(), data.RPCURL); err != nil {
+				// leave currentUrl untouched so that the next poll retries the switch
+				// instead of silently dropping the network
+				log.Err(err).Str("network", w.network.String()).Msg("failed to apply new rpc url")
+				return false, nil
+			}
+		}
+
+		w.mx.Lock()
+		w.currentUrl = data.RPCURL
+		w.mx.Unlock()
+
+		log.Info().Str("network", parts[0]).Str("url", data.RPCURL).Msg("new url was found")
+		return true, nil
 	}
 
 	return false, nil
@@ -150,5 +163,7 @@ func (w *Worker) checkNetwork(ctx context.Context) (bool, error) {
 
 // URL -
 func (w *Worker) URL() string {
+	w.mx.RLock()
+	defer w.mx.RUnlock()
 	return w.currentUrl
 }

--- a/internal/periodic/worker.go
+++ b/internal/periodic/worker.go
@@ -3,6 +3,7 @@ package periodic
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/baking-bad/bcdhub/internal/models/types"
@@ -19,6 +20,7 @@ type Worker struct {
 	cron       *cron.Cron
 	currentUrl string
 	handler    ChangedHandler
+	isRunning  atomic.Bool
 }
 
 // ChangedHandler -
@@ -76,6 +78,12 @@ func (w *Worker) Close() error {
 
 func (w *Worker) handleScheduleEvent(ctx context.Context) func() {
 	return func() {
+		if !w.isRunning.CompareAndSwap(false, true) {
+			log.Warn().Str("network", w.network.String()).Msg("periodic worker is already running")
+			return
+		}
+		defer w.isRunning.Store(false)
+
 		log.Info().Str("network", w.network.String()).Msg("trying to receive new rpc url")
 
 		changed, err := w.checkNetwork(ctx)

--- a/internal/periodic/worker_test.go
+++ b/internal/periodic/worker_test.go
@@ -1,0 +1,364 @@
+package periodic
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/baking-bad/bcdhub/internal/models/types"
+	"github.com/baking-bad/bcdhub/internal/teztnets"
+	"github.com/stretchr/testify/require"
+)
+
+// teztnetsServer serves a teztnets.json whose contents can be swapped between calls.
+func teztnetsServer(t *testing.T, info *atomic.Value) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/teztnets.json", r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode(info.Load().(teztnets.Info)))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// mustNotBlock runs f and fails the test if it does not return in time. Every call that
+// takes the worker mutex goes through it, so a lock left held by checkNetwork surfaces
+// as a failure instead of hanging the test binary until the go test timeout.
+func mustNotBlock(t *testing.T, name string, f func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s blocked: the worker mutex was left locked", name)
+	}
+}
+
+func TestWorkerCheckNetwork(t *testing.T) {
+	var info atomic.Value
+	info.Store(teztnets.Info{
+		"mainnet":  {RPCURL: "https://rpc.example.com/one"},
+		"ghostnet": {RPCURL: "https://rpc.example.com/other-network"},
+	})
+	srv := teztnetsServer(t, &info)
+
+	var handled []string
+	w, err := New(
+		Config{InfoBaseURL: srv.URL},
+		types.Mainnet,
+		func(ctx context.Context, network, newUrl string) error {
+			handled = append(handled, newUrl)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	check := func(t *testing.T) bool {
+		t.Helper()
+
+		var (
+			changed bool
+			err     error
+		)
+		mustNotBlock(t, "checkNetwork", func() { changed, err = w.checkNetwork(ctx) })
+		require.NoError(t, err)
+		return changed
+	}
+
+	url := func(t *testing.T) string {
+		t.Helper()
+
+		var url string
+		mustNotBlock(t, "URL()", func() { url = w.URL() })
+		return url
+	}
+
+	t.Run("first observation is adopted without calling the handler", func(t *testing.T) {
+		require.True(t, check(t))
+		require.Empty(t, handled)
+		require.Equal(t, "https://rpc.example.com/one", url(t))
+	})
+
+	t.Run("unchanged url is a no-op", func(t *testing.T) {
+		require.False(t, check(t))
+		require.Empty(t, handled)
+		require.Equal(t, "https://rpc.example.com/one", url(t))
+	})
+
+	t.Run("new url calls the handler and is adopted", func(t *testing.T) {
+		info.Store(teztnets.Info{"mainnet": {RPCURL: "https://rpc.example.com/two"}})
+
+		require.True(t, check(t))
+		require.Equal(t, []string{"https://rpc.example.com/two"}, handled)
+		require.Equal(t, "https://rpc.example.com/two", url(t))
+	})
+}
+
+// TestWorkerURLDuringHandler pins that the worker does not hold its own mutex while the
+// change handler runs: handleUrlChanged waits for the indexer loop to exit and then
+// re-initialises it, and URL() must stay answerable for that whole time.
+func TestWorkerURLDuringHandler(t *testing.T) {
+	var info atomic.Value
+	info.Store(teztnets.Info{"mainnet": {RPCURL: "https://rpc.example.com/one"}})
+	srv := teztnetsServer(t, &info)
+
+	var w *Worker
+	seen := make(chan string, 1)
+	w, err := New(
+		Config{InfoBaseURL: srv.URL},
+		types.Mainnet,
+		func(ctx context.Context, network, newUrl string) error {
+			var url string
+			mustNotBlock(t, "URL() inside the handler", func() { url = w.URL() })
+			seen <- url
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	mustNotBlock(t, "checkNetwork", func() { _, err = w.checkNetwork(ctx) })
+	require.NoError(t, err)
+
+	info.Store(teztnets.Info{"mainnet": {RPCURL: "https://rpc.example.com/two"}})
+	mustNotBlock(t, "checkNetwork", func() { _, err = w.checkNetwork(ctx) })
+	require.NoError(t, err)
+
+	require.Equal(t, "https://rpc.example.com/one", <-seen)
+}
+
+func TestGeneralWorkerCheckNetwork(t *testing.T) {
+	var info atomic.Value
+	info.Store(teztnets.Info{
+		"mainnet":  {RPCURL: "https://rpc.example.com/mainnet"},
+		"ghostnet": {RPCURL: "https://rpc.example.com/ghostnet"},
+	})
+	srv := teztnetsServer(t, &info)
+
+	handled := make(map[string]string)
+	w, err := NewGeneralWorker(
+		Config{InfoBaseURL: srv.URL},
+		func(ctx context.Context, network, newUrl string) error {
+			handled[network] = newUrl
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	check := func(t *testing.T) bool {
+		t.Helper()
+
+		var (
+			changed bool
+			err     error
+		)
+		mustNotBlock(t, "checkNetwork", func() { changed, err = w.checkNetwork(ctx) })
+		require.NoError(t, err)
+		return changed
+	}
+
+	urls := func(t *testing.T) map[string]string {
+		t.Helper()
+
+		var urls map[string]string
+		mustNotBlock(t, "URLs()", func() { urls = w.URLs() })
+		return urls
+	}
+
+	// Unlike Worker, GeneralWorker has no "skip the handler on the first observation"
+	// guard, so every network it learns about is reported to the handler right away.
+	t.Run("every network is adopted and handled on the first observation", func(t *testing.T) {
+		require.True(t, check(t))
+		require.Equal(t, map[string]string{
+			"mainnet":  "https://rpc.example.com/mainnet",
+			"ghostnet": "https://rpc.example.com/ghostnet",
+		}, handled)
+		require.Equal(t, map[string]string{
+			"mainnet":  "https://rpc.example.com/mainnet",
+			"ghostnet": "https://rpc.example.com/ghostnet",
+		}, urls(t))
+	})
+
+	t.Run("unchanged urls are a no-op", func(t *testing.T) {
+		require.False(t, check(t))
+		require.Equal(t, map[string]string{
+			"mainnet":  "https://rpc.example.com/mainnet",
+			"ghostnet": "https://rpc.example.com/ghostnet",
+		}, handled)
+	})
+
+	t.Run("only the changed network is handled", func(t *testing.T) {
+		info.Store(teztnets.Info{
+			"mainnet":  {RPCURL: "https://rpc.example.com/mainnet"},
+			"ghostnet": {RPCURL: "https://rpc.example.com/ghostnet-2"},
+		})
+
+		require.True(t, check(t))
+		require.Equal(t, map[string]string{
+			"mainnet":  "https://rpc.example.com/mainnet",
+			"ghostnet": "https://rpc.example.com/ghostnet-2",
+		}, handled)
+	})
+
+	t.Run("URLs returns a copy", func(t *testing.T) {
+		got := urls(t)
+		got["mainnet"] = "mutated"
+		delete(got, "ghostnet")
+
+		require.Equal(t, map[string]string{
+			"mainnet":  "https://rpc.example.com/mainnet",
+			"ghostnet": "https://rpc.example.com/ghostnet-2",
+		}, urls(t))
+	})
+}
+
+// TestWorkerRetriesAfterHandlerError pins that a failed switch is retried: the worker
+// must not adopt a url it could not apply, otherwise the network silently stops being
+// indexed behind a single log line.
+func TestWorkerRetriesAfterHandlerError(t *testing.T) {
+	var info atomic.Value
+	info.Store(teztnets.Info{"mainnet": {RPCURL: "https://rpc.example.com/one"}})
+	srv := teztnetsServer(t, &info)
+
+	var fail atomic.Bool
+	fail.Store(true)
+
+	var calls int
+	w, err := New(
+		Config{InfoBaseURL: srv.URL},
+		types.Mainnet,
+		func(ctx context.Context, network, newUrl string) error {
+			calls++
+			if fail.Load() {
+				return errors.New("reinit failed")
+			}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	check := func(t *testing.T) bool {
+		t.Helper()
+
+		var (
+			changed bool
+			err     error
+		)
+		mustNotBlock(t, "checkNetwork", func() { changed, err = w.checkNetwork(ctx) })
+		require.NoError(t, err)
+		return changed
+	}
+
+	url := func(t *testing.T) string {
+		t.Helper()
+
+		var url string
+		mustNotBlock(t, "URL()", func() { url = w.URL() })
+		return url
+	}
+
+	// first observation is adopted without the handler
+	require.True(t, check(t))
+	require.Zero(t, calls)
+	require.Equal(t, "https://rpc.example.com/one", url(t))
+
+	info.Store(teztnets.Info{"mainnet": {RPCURL: "https://rpc.example.com/two"}})
+
+	// the handler fails, so the old url stays in place and nothing is reported as changed
+	require.False(t, check(t))
+	require.Equal(t, 1, calls)
+	require.Equal(t, "https://rpc.example.com/one", url(t))
+
+	// the next poll tries again
+	fail.Store(false)
+	require.True(t, check(t))
+	require.Equal(t, 2, calls)
+	require.Equal(t, "https://rpc.example.com/two", url(t))
+}
+
+// TestGeneralWorkerRetriesAfterHandlerError is the GeneralWorker counterpart: a network
+// whose handler failed keeps its old url and is retried, while the others are unaffected.
+func TestGeneralWorkerRetriesAfterHandlerError(t *testing.T) {
+	var info atomic.Value
+	info.Store(teztnets.Info{
+		"mainnet":  {RPCURL: "https://rpc.example.com/mainnet"},
+		"ghostnet": {RPCURL: "https://rpc.example.com/ghostnet"},
+	})
+	srv := teztnetsServer(t, &info)
+
+	var failing atomic.Value
+	failing.Store("")
+
+	w, err := NewGeneralWorker(
+		Config{InfoBaseURL: srv.URL},
+		func(ctx context.Context, network, newUrl string) error {
+			if failing.Load().(string) == network {
+				return errors.New("reinit failed")
+			}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	check := func(t *testing.T) bool {
+		t.Helper()
+
+		var (
+			changed bool
+			err     error
+		)
+		mustNotBlock(t, "checkNetwork", func() { changed, err = w.checkNetwork(ctx) })
+		require.NoError(t, err)
+		return changed
+	}
+
+	urls := func(t *testing.T) map[string]string {
+		t.Helper()
+
+		var urls map[string]string
+		mustNotBlock(t, "URLs()", func() { urls = w.URLs() })
+		return urls
+	}
+
+	require.True(t, check(t))
+
+	failing.Store("ghostnet")
+	info.Store(teztnets.Info{
+		"mainnet":  {RPCURL: "https://rpc.example.com/mainnet-2"},
+		"ghostnet": {RPCURL: "https://rpc.example.com/ghostnet-2"},
+	})
+
+	require.True(t, check(t))
+	require.Equal(t, map[string]string{
+		"mainnet":  "https://rpc.example.com/mainnet-2",
+		"ghostnet": "https://rpc.example.com/ghostnet",
+	}, urls(t))
+
+	failing.Store("")
+	require.True(t, check(t))
+	require.Equal(t, map[string]string{
+		"mainnet":  "https://rpc.example.com/mainnet-2",
+		"ghostnet": "https://rpc.example.com/ghostnet-2",
+	}, urls(t))
+}


### PR DESCRIPTION
Fixes several race conditions and edge cases in the indexer.

**Ticker handling (`cmd/indexer/indexer/indexer.go`)**
The update ticker was created and stopped from goroutines other than the one
consuming it, and `setUpdateTicker` blocked on `refreshTimer` while a closed
channel could be written to on shutdown. The ticker is now owned exclusively by
the `Start` loop: `setUpdateTicker` only sends the desired interval over
`refreshTimer` (non-blocking, dropped with a warning if the queue is full) and
the loop resets the ticker itself. `refreshTimer` is no longer closed in `Close`.
The protocol's `TimeBetweenBlocks` is kept in an `atomic.Int64` so it can be read
safely after a protocol migration.

**Rollback depth (`getLastRollbackBlock`)**
The rollback search walked levels down without a lower bound and could run past
the configured start level. It now fails with an explicit error when a reorg is
deeper than the locally indexed history.

**Periodic indexer restart (`cmd/indexer/indexer/periodic.go`)**
On an RPC URL change the indexer was closed and re-initialised without waiting
for the previous `Start` loop to exit. The loop now signals its exit through an
`indexerDone` channel that `handleUrlChanged` waits on before calling `Close` and
`reinit`.

**Overlapping periodic runs (`internal/periodic`)**
Both `Worker` and `GeneralWorker` could start a new schedule handler while the
previous one was still running. Each now guards its handler with an
`atomic.Bool` and skips (with a warning) if a run is already in progress.